### PR TITLE
Starter .base File Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ views:
 
 ### Non-goals (still)
 
-No writing back to JIRA, no scheduled refresh, no starter `.base` files, no mobile.
+No writing back to JIRA, no scheduled refresh, no mobile.
 
 ## v0.4 — Issue lookup & preview
 
@@ -82,3 +82,38 @@ No writing back to JIRA, no scheduled refresh, no starter `.base` files, no mobi
 - **JIRA: Look up issue…** — command-palette modal that accepts a key (`ABC-123`) or a browse URL and renders the same preview.
 
 The preview uses the same JIRA client as the rest of the plugin — no extra config.
+
+## v0.5 — Starter .base file generator
+
+Instantly create a pre-configured Obsidian Bases view for your JIRA issues — no manual setup required.
+
+### How it works
+
+- **JIRA: Generate Bases view** — opens a modal where you select which columns to include (key, summary, status, type, priority, assignee, reporter, labels, updated, url). Click "Generate" and the plugin creates a ready-to-use `.base` file in your stubs folder.
+- The generated file is named `JIRA Issues.base` and lives in your configured stubs folder (default `JIRA/`).
+- Open the `.base` file with Obsidian Bases and you'll see a sortable, filterable table of all your JIRA issue stubs.
+
+### Column customization
+
+Default columns: key, summary, status, type, priority, assignee. Uncheck any you don't need, or add reporter, labels, updated, or url.
+
+### Example output
+
+```yaml
+filters:
+  and:
+    - file.inFolder("JIRA")
+views:
+  - type: table
+    name: "All issues"
+    order:
+      - file.name
+      - jira_key
+      - jira_summary
+      - jira_status
+      - jira_type
+      - jira_priority
+      - jira_assignee
+```
+
+Run "JIRA: Sync issue stubs" first to populate your stubs folder, then generate the view. The table updates automatically as you sync new issues.

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -12,3 +12,107 @@ export class Notice {
 }
 
 export class App {}
+
+export class Modal {
+  app: unknown;
+  contentEl: HTMLElement & { empty: () => void; createEl: (tag: string, options?: any) => HTMLElement };
+  titleEl: HTMLElement & { setText: (text: string) => void };
+
+  constructor(app: unknown) {
+    this.app = app;
+
+    const contentEl = document.createElement("div") as any;
+    contentEl.empty = function() {
+      this.innerHTML = "";
+    };
+    contentEl.createEl = function(tag: string, options?: any) {
+      const el = document.createElement(tag);
+      if (options?.text) {
+        el.textContent = options.text;
+      }
+      this.appendChild(el);
+      return el;
+    };
+    this.contentEl = contentEl;
+
+    const titleEl = document.createElement("div") as any;
+    titleEl.setText = function(text: string) {
+      this.textContent = text;
+    };
+    this.titleEl = titleEl;
+  }
+
+  open() {}
+  close() {}
+  onOpen() {}
+  onClose() {}
+}
+
+export class Setting {
+  private settingEl: HTMLElement;
+  private nameEl: HTMLElement;
+  private controlEl: HTMLElement;
+
+  constructor(containerEl: HTMLElement) {
+    this.settingEl = document.createElement("div");
+    this.settingEl.className = "setting-item";
+
+    this.nameEl = document.createElement("div");
+    this.nameEl.className = "setting-item-name";
+
+    this.controlEl = document.createElement("div");
+    this.controlEl.className = "setting-item-control";
+
+    this.settingEl.appendChild(this.nameEl);
+    this.settingEl.appendChild(this.controlEl);
+    containerEl.appendChild(this.settingEl);
+  }
+
+  setName(name: string): this {
+    this.nameEl.textContent = name;
+    return this;
+  }
+
+  addToggle(cb: (toggle: { setValue: (value: boolean) => any; onChange: (cb: (value: boolean) => void) => void }) => void): this {
+    const toggleEl = document.createElement("input");
+    toggleEl.type = "checkbox";
+    this.controlEl.appendChild(toggleEl);
+
+    const toggle = {
+      setValue: (value: boolean) => {
+        toggleEl.checked = value;
+        return toggle;
+      },
+      onChange: (callback: (value: boolean) => void) => {
+        toggleEl.addEventListener("change", () => {
+          callback(toggleEl.checked);
+        });
+      },
+    };
+
+    cb(toggle);
+    return this;
+  }
+
+  addButton(cb: (button: { setButtonText: (text: string) => any; setCta: () => any; onClick: (cb: () => void) => void }) => void): this {
+    const buttonEl = document.createElement("button");
+    this.controlEl.appendChild(buttonEl);
+
+    const button = {
+      setButtonText: (text: string) => {
+        buttonEl.textContent = text;
+        return button;
+      },
+      setCta: () => {
+        buttonEl.className = "mod-cta";
+        return button;
+      },
+      onClick: (callback: () => void) => {
+        buttonEl.addEventListener("click", callback);
+      },
+    };
+
+    cb(button);
+    return this;
+  }
+}

--- a/src/base-generator-modal.test.ts
+++ b/src/base-generator-modal.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BaseGeneratorModal } from "./base-generator-modal";
+
+function createModal(opts: { onGenerate?: (columns: string[]) => void } = {}) {
+  const onGenerate = opts.onGenerate ?? vi.fn();
+  return new BaseGeneratorModal({ vault: {} } as any, onGenerate);
+}
+
+describe("BaseGeneratorModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("initialization", () => {
+    it("initializes with default checked columns", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+
+      // Trigger generate to see which columns are selected
+      modal.onOpen();
+      const generateButton = modal.contentEl.querySelector(
+        'button[class*="mod-cta"]',
+      ) as HTMLButtonElement;
+      generateButton?.click();
+
+      expect(onGenerate).toHaveBeenCalledWith(
+        expect.arrayContaining(["key", "summary", "status", "type", "priority", "assignee"]),
+      );
+      expect(onGenerate).toHaveBeenCalledWith(
+        expect.not.arrayContaining(["reporter", "labels", "updated"]),
+      );
+    });
+
+    it("creates modal with onGenerate callback", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+      expect(modal).toBeDefined();
+    });
+  });
+
+  describe("column selection", () => {
+    it("includes all default columns when none are toggled off", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+
+      modal.onOpen();
+      const generateButton = modal.contentEl.querySelector(
+        'button[class*="mod-cta"]',
+      ) as HTMLButtonElement;
+      generateButton?.click();
+
+      const selectedColumns = onGenerate.mock.calls[0][0];
+      expect(selectedColumns).toContain("key");
+      expect(selectedColumns).toContain("summary");
+      expect(selectedColumns).toContain("status");
+      expect(selectedColumns).toContain("type");
+      expect(selectedColumns).toContain("priority");
+      expect(selectedColumns).toContain("assignee");
+      expect(selectedColumns.length).toBe(6);
+    });
+
+    it("adds non-default column when toggled on", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+
+      modal.onOpen();
+
+      // Find and toggle the "Reporter" checkbox (not default checked)
+      const toggles = modal.contentEl.querySelectorAll('input[type="checkbox"]');
+      const reporterToggle = Array.from(toggles).find((toggle) => {
+        const setting = toggle.closest(".setting-item");
+        return setting?.querySelector(".setting-item-name")?.textContent === "Reporter";
+      }) as HTMLInputElement;
+
+      if (reporterToggle) {
+        reporterToggle.checked = true;
+        reporterToggle.dispatchEvent(new Event("change"));
+      }
+
+      const generateButton = modal.contentEl.querySelector(
+        'button[class*="mod-cta"]',
+      ) as HTMLButtonElement;
+      generateButton?.click();
+
+      const selectedColumns = onGenerate.mock.calls[0][0];
+      expect(selectedColumns).toContain("reporter");
+    });
+
+    it("removes default column when toggled off", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+
+      modal.onOpen();
+
+      // Find and toggle off the "Status" checkbox (default checked)
+      const toggles = modal.contentEl.querySelectorAll('input[type="checkbox"]');
+      const statusToggle = Array.from(toggles).find((toggle) => {
+        const setting = toggle.closest(".setting-item");
+        return setting?.querySelector(".setting-item-name")?.textContent === "Status";
+      }) as HTMLInputElement;
+
+      if (statusToggle) {
+        statusToggle.checked = false;
+        statusToggle.dispatchEvent(new Event("change"));
+      }
+
+      const generateButton = modal.contentEl.querySelector(
+        'button[class*="mod-cta"]',
+      ) as HTMLButtonElement;
+      generateButton?.click();
+
+      const selectedColumns = onGenerate.mock.calls[0][0];
+      expect(selectedColumns).not.toContain("status");
+    });
+  });
+
+  describe("generate button", () => {
+    it("calls onGenerate with selected columns array", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+
+      modal.onOpen();
+      const generateButton = modal.contentEl.querySelector(
+        'button[class*="mod-cta"]',
+      ) as HTMLButtonElement;
+      generateButton?.click();
+
+      expect(onGenerate).toHaveBeenCalledTimes(1);
+      expect(onGenerate).toHaveBeenCalledWith(expect.any(Array));
+    });
+
+    it("closes modal when generate is clicked", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+      const closeSpy = vi.spyOn(modal, "close");
+
+      modal.onOpen();
+      const generateButton = modal.contentEl.querySelector(
+        'button[class*="mod-cta"]',
+      ) as HTMLButtonElement;
+      generateButton?.click();
+
+      expect(closeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("cancel button", () => {
+    it("closes modal without calling onGenerate", () => {
+      const onGenerate = vi.fn();
+      const modal = createModal({ onGenerate });
+      const closeSpy = vi.spyOn(modal, "close");
+
+      modal.onOpen();
+      const buttons = modal.contentEl.querySelectorAll("button");
+      const cancelButton = Array.from(buttons).find(
+        (btn) => btn.textContent === "Cancel",
+      );
+      cancelButton?.click();
+
+      expect(closeSpy).toHaveBeenCalled();
+      expect(onGenerate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("modal lifecycle", () => {
+    it("sets title on open", () => {
+      const modal = createModal();
+      modal.onOpen();
+
+      expect(modal.titleEl.textContent).toBe("Generate JIRA Bases View");
+    });
+
+    it("creates description paragraph on open", () => {
+      const modal = createModal();
+      modal.onOpen();
+
+      const paragraph = modal.contentEl.querySelector("p");
+      expect(paragraph?.textContent).toBe(
+        "Select which columns to include in your JIRA issues table:",
+      );
+    });
+
+    it("clears content on close", () => {
+      const modal = createModal();
+      modal.onOpen();
+
+      expect(modal.contentEl.children.length).toBeGreaterThan(0);
+
+      modal.onClose();
+      expect(modal.contentEl.children.length).toBe(0);
+    });
+  });
+
+  describe("column options", () => {
+    it("displays all available column options", () => {
+      const modal = createModal();
+      modal.onOpen();
+
+      const expectedColumns = [
+        "Issue Key",
+        "Summary",
+        "Status",
+        "Type",
+        "Priority",
+        "Assignee",
+        "Reporter",
+        "Labels",
+        "Updated",
+      ];
+
+      const settings = modal.contentEl.querySelectorAll(".setting-item-name");
+      const displayedColumns = Array.from(settings)
+        .map((el) => el.textContent)
+        .filter((text) => expectedColumns.includes(text || ""));
+
+      expect(displayedColumns.length).toBe(expectedColumns.length);
+      expectedColumns.forEach((col) => {
+        expect(displayedColumns).toContain(col);
+      });
+    });
+
+    it("sets correct default states for toggles", () => {
+      const modal = createModal();
+      modal.onOpen();
+
+      const toggles = modal.contentEl.querySelectorAll('input[type="checkbox"]');
+
+      // Check that default columns are checked
+      const defaultCheckedColumns = ["Issue Key", "Summary", "Status", "Type", "Priority", "Assignee"];
+      defaultCheckedColumns.forEach((colName) => {
+        const toggle = Array.from(toggles).find((t) => {
+          const setting = t.closest(".setting-item");
+          return setting?.querySelector(".setting-item-name")?.textContent === colName;
+        }) as HTMLInputElement;
+        expect(toggle?.checked).toBe(true);
+      });
+
+      // Check that non-default columns are unchecked
+      const defaultUncheckedColumns = ["Reporter", "Labels", "Updated"];
+      defaultUncheckedColumns.forEach((colName) => {
+        const toggle = Array.from(toggles).find((t) => {
+          const setting = t.closest(".setting-item");
+          return setting?.querySelector(".setting-item-name")?.textContent === colName;
+        }) as HTMLInputElement;
+        expect(toggle?.checked).toBe(false);
+      });
+    });
+  });
+});

--- a/src/base-generator-modal.ts
+++ b/src/base-generator-modal.ts
@@ -1,0 +1,72 @@
+import { App, Modal, Setting } from "obsidian";
+
+export interface ColumnOption {
+  id: string;
+  label: string;
+  defaultChecked: boolean;
+}
+
+const AVAILABLE_COLUMNS: ColumnOption[] = [
+  { id: "key", label: "Issue Key", defaultChecked: true },
+  { id: "summary", label: "Summary", defaultChecked: true },
+  { id: "status", label: "Status", defaultChecked: true },
+  { id: "type", label: "Type", defaultChecked: true },
+  { id: "priority", label: "Priority", defaultChecked: true },
+  { id: "assignee", label: "Assignee", defaultChecked: true },
+  { id: "reporter", label: "Reporter", defaultChecked: false },
+  { id: "labels", label: "Labels", defaultChecked: false },
+  { id: "updated", label: "Updated", defaultChecked: false },
+];
+
+export class BaseGeneratorModal extends Modal {
+  private selectedColumns: Set<string>;
+
+  constructor(
+    app: App,
+    private onGenerate: (columns: string[]) => void,
+  ) {
+    super(app);
+    this.selectedColumns = new Set(
+      AVAILABLE_COLUMNS.filter((c) => c.defaultChecked).map((c) => c.id),
+    );
+  }
+
+  onOpen(): void {
+    const { contentEl, titleEl } = this;
+    titleEl.setText("Generate JIRA Bases View");
+
+    contentEl.createEl("p", {
+      text: "Select which columns to include in your JIRA issues table:",
+    });
+
+    for (const column of AVAILABLE_COLUMNS) {
+      new Setting(contentEl).setName(column.label).addToggle((toggle) =>
+        toggle.setValue(column.defaultChecked).onChange((value) => {
+          if (value) {
+            this.selectedColumns.add(column.id);
+          } else {
+            this.selectedColumns.delete(column.id);
+          }
+        }),
+      );
+    }
+
+    new Setting(contentEl)
+      .addButton((btn) =>
+        btn.setButtonText("Cancel").onClick(() => this.close()),
+      )
+      .addButton((btn) =>
+        btn
+          .setButtonText("Generate")
+          .setCta()
+          .onClick(() => {
+            this.close();
+            this.onGenerate(Array.from(this.selectedColumns));
+          }),
+      );
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/base-generator.test.ts
+++ b/src/base-generator.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { generateBase, type BaseConfig } from "./base-generator";
+
+describe("generateBase", () => {
+  it("generates a minimal base with default view name", () => {
+    const config: BaseConfig = {
+      columns: ["key", "summary"],
+      stubsFolder: "JIRA",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("JIRA")');
+    expect(base).toContain('name: "All issues"');
+    expect(base).toContain("- file.name");
+    expect(base).toContain("- jira_key");
+    expect(base).toContain("- jira_summary");
+  });
+
+  it("uses custom view name when provided", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: "JIRA",
+      viewName: "My Custom View",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('name: "My Custom View"');
+  });
+
+  it("includes all mapped columns in the order list", () => {
+    const config: BaseConfig = {
+      columns: ["key", "summary", "status", "type", "priority", "assignee", "reporter", "labels", "updated", "url"],
+      stubsFolder: "JIRA",
+    };
+    const base = generateBase(config);
+    expect(base).toContain("- file.name");
+    expect(base).toContain("- jira_key");
+    expect(base).toContain("- jira_summary");
+    expect(base).toContain("- jira_status");
+    expect(base).toContain("- jira_type");
+    expect(base).toContain("- jira_priority");
+    expect(base).toContain("- jira_assignee");
+    expect(base).toContain("- jira_reporter");
+    expect(base).toContain("- jira_labels");
+    expect(base).toContain("- jira_updated");
+    expect(base).toContain("- jira_url");
+  });
+
+  it("skips unmapped columns", () => {
+    const config: BaseConfig = {
+      columns: ["key", "unknown_column", "summary"],
+      stubsFolder: "JIRA",
+    };
+    const base = generateBase(config);
+    expect(base).toContain("- file.name");
+    expect(base).toContain("- jira_key");
+    expect(base).toContain("- jira_summary");
+    expect(base).not.toContain("unknown_column");
+  });
+
+  it("always includes file.name as the first order field", () => {
+    const config: BaseConfig = {
+      columns: ["summary"],
+      stubsFolder: "JIRA",
+    };
+    const base = generateBase(config);
+    const lines = base.split("\n");
+    const orderIndex = lines.findIndex((l) => l.includes("order:"));
+    expect(lines[orderIndex + 1]).toContain("- file.name");
+  });
+
+  it("normalizes folder path by removing leading slashes", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: "/JIRA",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("JIRA")');
+  });
+
+  it("normalizes folder path by removing trailing slashes", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: "JIRA/",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("JIRA")');
+  });
+
+  it("normalizes folder path by removing both leading and trailing slashes", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: "/JIRA/",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("JIRA")');
+  });
+
+  it("escapes double quotes in folder path", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: 'My "JIRA" Folder',
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("My \\"JIRA\\" Folder")');
+  });
+
+  it("escapes backslashes in folder path", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: "JIRA\\Subfolder",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("JIRA\\\\Subfolder")');
+  });
+
+  it("generates well-formed YAML structure", () => {
+    const config: BaseConfig = {
+      columns: ["key", "summary", "status"],
+      stubsFolder: "JIRA",
+    };
+    const base = generateBase(config);
+    expect(base).toMatch(/^filters:\n  and:\n    - file\.inFolder/);
+    expect(base).toContain("views:\n  - type: table");
+    expect(base).toContain("order:\n      - file.name");
+  });
+
+  it("handles empty columns array by only including file.name", () => {
+    const config: BaseConfig = {
+      columns: [],
+      stubsFolder: "JIRA",
+    };
+    const base = generateBase(config);
+    expect(base).toContain("- file.name");
+    expect(base).not.toContain("- jira_");
+  });
+
+  it("preserves column order in the output", () => {
+    const config: BaseConfig = {
+      columns: ["priority", "key", "summary"],
+      stubsFolder: "JIRA",
+    };
+    const base = generateBase(config);
+    const lines = base.split("\n");
+    const fileNameIndex = lines.findIndex((l) => l.includes("- file.name"));
+    const priorityIndex = lines.findIndex((l) => l.includes("- jira_priority"));
+    const keyIndex = lines.findIndex((l) => l.includes("- jira_key"));
+    const summaryIndex = lines.findIndex((l) => l.includes("- jira_summary"));
+
+    expect(fileNameIndex).toBeLessThan(priorityIndex);
+    expect(priorityIndex).toBeLessThan(keyIndex);
+    expect(keyIndex).toBeLessThan(summaryIndex);
+  });
+
+  it("handles nested folder paths", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: "Projects/JIRA/Active",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("Projects/JIRA/Active")');
+  });
+
+  it("handles folder paths with spaces", () => {
+    const config: BaseConfig = {
+      columns: ["key"],
+      stubsFolder: "My JIRA Issues",
+    };
+    const base = generateBase(config);
+    expect(base).toContain('file.inFolder("My JIRA Issues")');
+  });
+});

--- a/src/base-generator.ts
+++ b/src/base-generator.ts
@@ -1,0 +1,51 @@
+export interface BaseConfig {
+  columns: string[];
+  stubsFolder: string;
+  viewName?: string;
+}
+
+const COLUMN_TO_FIELD: Record<string, string> = {
+  key: "jira_key",
+  summary: "jira_summary",
+  status: "jira_status",
+  type: "jira_type",
+  priority: "jira_priority",
+  assignee: "jira_assignee",
+  reporter: "jira_reporter",
+  labels: "jira_labels",
+  updated: "jira_updated",
+  url: "jira_url",
+};
+
+function escapeFolderPath(folder: string): string {
+  const normalized = folder.replace(/^\/+|\/+$/g, "");
+  // Escape double quotes and backslashes for YAML string
+  return normalized.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function emitOrderList(columns: string[]): string {
+  const fields = ["file.name"];
+  for (const col of columns) {
+    const field = COLUMN_TO_FIELD[col];
+    if (field) {
+      fields.push(field);
+    }
+  }
+  return fields.map((f) => `      - ${f}`).join("\n");
+}
+
+export function generateBase(config: BaseConfig): string {
+  const { columns, stubsFolder, viewName = "All issues" } = config;
+  const escapedFolder = escapeFolderPath(stubsFolder);
+  const orderLines = emitOrderList(columns);
+
+  return `filters:
+  and:
+    - file.inFolder("${escapedFolder}")
+views:
+  - type: table
+    name: "${viewName}"
+    order:
+${orderLines}
+`;
+}

--- a/src/integration-base-generator.test.ts
+++ b/src/integration-base-generator.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import { generateBase, type BaseConfig } from "./base-generator";
+import { VaultAdapter } from "./stub-writer";
+
+function inMemoryVault(initial: Record<string, string> = {}): VaultAdapter & {
+  files: Map<string, string>;
+  folders: Set<string>;
+} {
+  const files = new Map<string, string>(Object.entries(initial));
+  const folders = new Set<string>();
+  return {
+    files,
+    folders,
+    async read(path) {
+      return files.has(path) ? files.get(path)! : null;
+    },
+    async write(path, content) {
+      files.set(path, content);
+    },
+    async exists(path) {
+      return files.has(path);
+    },
+    async ensureFolder(path) {
+      folders.add(path);
+    },
+  };
+}
+
+async function runEndToEndFlow(
+  vault: VaultAdapter,
+  columns: string[],
+  stubsFolder: string,
+  viewName?: string,
+): Promise<{ success: boolean; error?: string }> {
+  if (columns.length === 0) {
+    return { success: false, error: "Select at least one column." };
+  }
+  const baseContent = generateBase({
+    columns,
+    stubsFolder,
+    viewName,
+  });
+  const normalizedFolder = stubsFolder.replace(/\/+$/, "");
+  const baseFilePath = `${normalizedFolder}/JIRA Issues.base`;
+  try {
+    await vault.write(baseFilePath, baseContent);
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: (e as Error).message };
+  }
+}
+
+describe("integration: base generator end-to-end", () => {
+  it("creates base file with selected columns", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key", "summary", "status"], "JIRA");
+
+    expect(result.success).toBe(true);
+    expect(vault.files.has("JIRA/JIRA Issues.base")).toBe(true);
+
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+    expect(baseContent).toContain('file.inFolder("JIRA")');
+    expect(baseContent).toContain('name: "All issues"');
+    expect(baseContent).toContain("- file.name");
+    expect(baseContent).toContain("- jira_key");
+    expect(baseContent).toContain("- jira_summary");
+    expect(baseContent).toContain("- jira_status");
+  });
+
+  it("fails when no columns are selected", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, [], "JIRA");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Select at least one column.");
+    expect(vault.files.has("JIRA/JIRA Issues.base")).toBe(false);
+  });
+
+  it("overwrites existing base file", async () => {
+    const vault = inMemoryVault({
+      "JIRA/JIRA Issues.base": "old content",
+    });
+    const result = await runEndToEndFlow(vault, ["key", "summary"], "JIRA");
+
+    expect(result.success).toBe(true);
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+    expect(baseContent).not.toContain("old content");
+    expect(baseContent).toContain("- jira_key");
+    expect(baseContent).toContain("- jira_summary");
+  });
+
+  it("uses custom view name when provided", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key"], "JIRA", "My Custom View");
+
+    expect(result.success).toBe(true);
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+    expect(baseContent).toContain('name: "My Custom View"');
+  });
+
+  it("handles nested folder paths", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key", "summary"], "Projects/JIRA/Active");
+
+    expect(result.success).toBe(true);
+    expect(vault.files.has("Projects/JIRA/Active/JIRA Issues.base")).toBe(true);
+
+    const baseContent = vault.files.get("Projects/JIRA/Active/JIRA Issues.base")!;
+    expect(baseContent).toContain('file.inFolder("Projects/JIRA/Active")');
+  });
+
+  it("normalizes folder path with trailing slash", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key"], "JIRA/");
+
+    expect(result.success).toBe(true);
+    expect(vault.files.has("JIRA/JIRA Issues.base")).toBe(true);
+  });
+
+  it("creates base file with all available columns", async () => {
+    const vault = inMemoryVault();
+    const allColumns = ["key", "summary", "status", "type", "priority", "assignee", "reporter", "labels", "updated"];
+    const result = await runEndToEndFlow(vault, allColumns, "JIRA");
+
+    expect(result.success).toBe(true);
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+    expect(baseContent).toContain("- file.name");
+    expect(baseContent).toContain("- jira_key");
+    expect(baseContent).toContain("- jira_summary");
+    expect(baseContent).toContain("- jira_status");
+    expect(baseContent).toContain("- jira_type");
+    expect(baseContent).toContain("- jira_priority");
+    expect(baseContent).toContain("- jira_assignee");
+    expect(baseContent).toContain("- jira_reporter");
+    expect(baseContent).toContain("- jira_labels");
+    expect(baseContent).toContain("- jira_updated");
+  });
+
+  it("maintains column order in generated base file", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["priority", "key", "summary"], "JIRA");
+
+    expect(result.success).toBe(true);
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+    const lines = baseContent.split("\n");
+
+    const fileNameIndex = lines.findIndex((l) => l.includes("- file.name"));
+    const priorityIndex = lines.findIndex((l) => l.includes("- jira_priority"));
+    const keyIndex = lines.findIndex((l) => l.includes("- jira_key"));
+    const summaryIndex = lines.findIndex((l) => l.includes("- jira_summary"));
+
+    expect(fileNameIndex).toBeLessThan(priorityIndex);
+    expect(priorityIndex).toBeLessThan(keyIndex);
+    expect(keyIndex).toBeLessThan(summaryIndex);
+  });
+
+  it("handles folder paths with special characters", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key"], 'My "JIRA" Folder');
+
+    expect(result.success).toBe(true);
+    expect(vault.files.has('My "JIRA" Folder/JIRA Issues.base')).toBe(true);
+
+    const baseContent = vault.files.get('My "JIRA" Folder/JIRA Issues.base')!;
+    expect(baseContent).toContain('file.inFolder("My \\"JIRA\\" Folder")');
+  });
+
+  it("generates valid YAML structure", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key", "summary", "status"], "JIRA");
+
+    expect(result.success).toBe(true);
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+
+    expect(baseContent).toMatch(/^filters:\n  and:\n    - file\.inFolder/);
+    expect(baseContent).toContain("views:\n  - type: table");
+    expect(baseContent).toContain("order:\n      - file.name");
+  });
+
+  it("handles folder paths with spaces", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key", "summary"], "My JIRA Issues");
+
+    expect(result.success).toBe(true);
+    expect(vault.files.has("My JIRA Issues/JIRA Issues.base")).toBe(true);
+
+    const baseContent = vault.files.get("My JIRA Issues/JIRA Issues.base")!;
+    expect(baseContent).toContain('file.inFolder("My JIRA Issues")');
+  });
+
+  it("includes url column when selected", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key", "url"], "JIRA");
+
+    expect(result.success).toBe(true);
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+    expect(baseContent).toContain("- jira_url");
+  });
+
+  it("only includes file.name when single column is selected", async () => {
+    const vault = inMemoryVault();
+    const result = await runEndToEndFlow(vault, ["key"], "JIRA");
+
+    expect(result.success).toBe(true);
+    const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
+    expect(baseContent).toContain("- file.name");
+    expect(baseContent).toContain("- jira_key");
+    expect(baseContent).not.toContain("- jira_summary");
+    expect(baseContent).not.toContain("- jira_status");
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,8 @@ import {
 } from "./jira-key";
 import { CommentIssueSuggestModal } from "./comment-issue-modal";
 import type { Editor } from "obsidian";
+import { generateBase } from "./base-generator";
+import { BaseGeneratorModal } from "./base-generator-modal";
 
 const obsidianRequest: HttpRequest = async ({ url, headers, method, body }) => {
   const r = await requestUrl({ url, headers, method: method ?? "GET", body: body ?? undefined, throw: false });
@@ -190,6 +192,12 @@ export default class JiraBasesPlugin extends Plugin {
       id: "add-comment",
       name: "JIRA: Add comment to issue…",
       editorCallback: (editor) => this.addCommentToIssue(editor),
+    });
+
+    this.addCommand({
+      id: "generate-bases-view",
+      name: "JIRA: Generate Bases view",
+      callback: () => this.generateBasesView(),
     });
   }
 
@@ -649,6 +657,29 @@ export default class JiraBasesPlugin extends Plugin {
         new Notice(`Deleted ${deleted} orphaned stubs${failed ? ` (${failed} failed)` : ""}.`);
       },
     ).open();
+  }
+
+  async generateBasesView(): Promise<void> {
+    const modal = new BaseGeneratorModal(this.app, async (columns: string[]) => {
+      if (columns.length === 0) {
+        new Notice("Select at least one column.");
+        return;
+      }
+      const baseContent = generateBase({
+        columns,
+        stubsFolder: this.settings.stubsFolder,
+      });
+      const vault = this.makeVaultAdapter();
+      const stubsFolder = this.settings.stubsFolder.replace(/\/+$/, "");
+      const baseFilePath = `${stubsFolder}/JIRA Issues.base`;
+      try {
+        await vault.write(baseFilePath, baseContent);
+        new Notice(`Bases view created at ${baseFilePath}`);
+      } catch (e) {
+        new Notice(`Failed to create view: ${(e as Error).message}`);
+      }
+    });
+    modal.open();
   }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     environmentMatchGlobs: [
       ["src/**/issue-preview-view.test.ts", "jsdom"],
+      ["src/**/base-generator-modal.test.ts", "jsdom"],
     ],
   },
 });


### PR DESCRIPTION
Add a command that generates a pre-configured .base file in the vault, creating an Obsidian Bases view pre-wired to query JIRA issue stub notes by their frontmatter fields (status, type, priority, assignee). The generated view provides an instant project dashboard with sortable, filterable columns — no manual Bases setup required.