### PR TITLE
JB-5: add GitHub release CI — auto-publish on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,33 @@ on:
     branches:
       - main
 
+# Default to read-only; the release job explicitly escalates to write.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  release:
+  # ── Build ────────────────────────────────────────────────────────────────
+  # Runs with read-only repo access so that `npm ci` (and any postinstall
+  # scripts) cannot write to the repository.
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      skip:       ${{ steps.guard.outputs.skip }}
+      tag_exists: ${{ steps.guard.outputs.tag_exists }}
+      tag:        ${{ steps.version.outputs.tag }}
+      version:    ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Shallow checkout is sufficient — `--generate-notes` is resolved
+          # server-side by the GitHub API, not from local history.
+          fetch-depth: 1
           fetch-tags: true
 
       - name: Read manifest version
@@ -29,25 +42,53 @@ jobs:
             echo "ERROR: could not read a valid version from manifest.json" >&2
             exit 1
           fi
-          # Bare semver tag — no `v` prefix (BRAT/Obsidian community-plugin convention).
+          # Bare semver tag — no `v` prefix.
+          # BRAT and the Obsidian community-plugin installer both accept bare
+          # semver (e.g. 1.2.3) and v-prefixed (v1.2.3); bare semver is the
+          # predominant convention in the community plugin registry and is
+          # used here intentionally for consistency with other plugins.
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$version"     >> "$GITHUB_OUTPUT"
 
-      - name: Skip if tag already exists
+      - name: Check tag and release existence
         id: guard
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Re-fetch tags here so we catch any tag pushed by a concurrent run
+          # that finished after our initial checkout but before this check.
+          git fetch --tags
+
+          TAG_EXISTS=false
+          RELEASE_EXISTS=false
+
           if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
-            echo "Tag $TAG already exists; nothing to release."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            TAG_EXISTS=true
           fi
 
-      - name: Setup Node
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            RELEASE_EXISTS=true
+          fi
+
+          if [[ "$TAG_EXISTS" == "true" && "$RELEASE_EXISTS" == "true" ]]; then
+            echo "Tag and release $TAG already exist; nothing to release."
+            echo "skip=true"            >> "$GITHUB_OUTPUT"
+            echo "tag_exists=true"      >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG_EXISTS" == "true" && "$RELEASE_EXISTS" == "false" ]]; then
+            # A previous run pushed the tag but the release step failed
+            # (network blip, API error, etc.).  Skip re-tagging and let the
+            # release job finish what was left incomplete.
+            echo "Tag $TAG exists but release is missing; will create release only."
+            echo "skip=false"           >> "$GITHUB_OUTPUT"
+            echo "tag_exists=true"      >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false"           >> "$GITHUB_OUTPUT"
+            echo "tag_exists=false"     >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
         if: steps.guard.outputs.skip == 'false'
-        uses: actions/setup-node@v4
         with:
           node-version: "20"
 
@@ -56,13 +97,13 @@ jobs:
         run: |
           if ! npm ci; then
             {
-              echo "## ❌ \`npm ci\` failed — lockfile out of sync"
+              echo "## ❌ \`npm ci\` failed"
               echo ""
-              echo "**Likely cause:** \`package.json\` was edited without"
-              echo "regenerating \`package-lock.json\`."
+              echo "**Possible causes:** stale lockfile, npm registry outage,"
+              echo "or a peer-dependency conflict."
               echo ""
-              echo "**Fix:** run \`npm install\` and commit the updated"
-              echo "\`package-lock.json\` before merging."
+              echo "If the lockfile is out of sync, run \`npm install\` locally"
+              echo "and commit the updated \`package-lock.json\` before merging."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
@@ -71,22 +112,61 @@ jobs:
         if: steps.guard.outputs.skip == 'false'
         run: npm run build
 
-      - name: Create and push tag
+      - name: Verify build output
         if: steps.guard.outputs.skip == 'false'
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          git config user.name "github-actions[bot]"
+          test -f main.js || {
+            echo "ERROR: main.js not found after build — check esbuild.config.mjs outfile path" >&2
+            exit 1
+          }
+
+      - name: Upload release assets
+        if: steps.guard.outputs.skip == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: |
+            main.js
+            manifest.json
+            styles.css
+
+  # ── Release ──────────────────────────────────────────────────────────────
+  # Runs only when the build job signals work to do.  Elevated write
+  # permissions are scoped to this job only, keeping them away from npm ci.
+  release:
+    needs: build
+    if: needs.build.outputs.skip == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: true
+
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+
+      - name: Create and push tag
+        # Skip if the tag already exists (e.g. previous run pushed the tag but
+        # failed before creating the release).
+        if: needs.build.outputs.tag_exists == 'false'
+        env:
+          TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "$TAG"
           git push origin "$TAG"
 
       - name: Create release
-        if: steps.guard.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ needs.build.outputs.tag }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           gh release create "$TAG" \
             --title "JIRA Bases v$VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Read manifest version
+        id: version
+        run: |
+          version=$(jq -r .version manifest.json)
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "ERROR: could not read a valid version from manifest.json" >&2
+            exit 1
+          fi
+          # Bare semver tag — no `v` prefix (BRAT/Obsidian community-plugin convention).
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: guard
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node
+        if: steps.guard.outputs.skip == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          if ! npm ci; then
+            {
+              echo "## ❌ \`npm ci\` failed — lockfile out of sync"
+              echo ""
+              echo "**Likely cause:** \`package.json\` was edited without"
+              echo "regenerating \`package-lock.json\`."
+              echo ""
+              echo "**Fix:** run \`npm install\` and commit the updated"
+              echo "\`package-lock.json\` before merging."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Build
+        if: steps.guard.outputs.skip == 'false'
+        run: npm run build
+
+      - name: Create and push tag
+        if: steps.guard.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create release
+        if: steps.guard.outputs.skip == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$TAG" \
+            --title "JIRA Bases v$VERSION" \
+            --generate-notes \
+            main.js \
+            manifest.json \
+            styles.css


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` that auto-publishes a GitHub release on every push to `main`.
- Reads `version` from `manifest.json`, skips if the bare-semver tag already exists (idempotent on non-bump merges), otherwise `npm ci && npm run build`, tags, and `gh release create --generate-notes` attaching `main.js`, `manifest.json`, `styles.css`.
- Tag format is bare semver (no `v` prefix) per the BRAT/Obsidian community-plugin convention.

## Test plan
- [ ] Merge to `main` at version `0.6.0` → workflow runs, tags `0.6.0`, publishes a release with `main.js` + `manifest.json` + `styles.css`.
- [ ] A subsequent no-op merge to `main` → workflow runs, hits the tag-exists guard, exits clean (no duplicate release).
- [ ] Bump `manifest.json` to `0.7.0` and merge → new tag `0.7.0` + new release.

Resolves JB-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)