### PR TITLE
JB-12: Document non-goals (Cloud, OAuth, mobile, multi-account)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ None of them do quite what I want, which is:
 
 To keep scope tight, this plugin explicitly **does not** support:
 
-- **JIRA Cloud.** Targets JIRA Data Center / Server only. The Cloud REST API surface, auth flows, and pagination semantics differ; supporting both would double maintenance and dilute the Data Center experience.
+- **JIRA Cloud.** Targets JIRA Data Center only. The Cloud REST API surface, auth flows, and pagination semantics differ; supporting both would double maintenance and dilute the Data Center experience.
 - **OAuth.** Personal Access Token (PAT) only. No 3LO, no device flow, no SSO bridging.
 - **Mobile.** Desktop-only (`isDesktopOnly: true`). Token storage relies on Electron `safeStorage`, which has no mobile equivalent.
 - **Multi-account / multi-instance.** One JIRA base URL + token per vault.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ None of them do quite what I want, which is:
 - Auth: We can allow JIRA PAT but I would *prefer* to use human-in-the-middle OAuth for this where available (as in my case)
 - Combining the metadata, bases and plugin capabilities we should be able to design bases with rich information from JIRA
 
+## Non-goals
+
+To keep scope tight, this plugin explicitly **does not** support:
+
+- **JIRA Cloud.** Targets JIRA Data Center / Server only. The Cloud REST API surface, auth flows, and pagination semantics differ; supporting both would double maintenance and dilute the Data Center experience.
+- **OAuth.** Personal Access Token (PAT) only. No 3LO, no device flow, no SSO bridging.
+- **Mobile.** Desktop-only (`isDesktopOnly: true`). Token storage relies on Electron `safeStorage`, which has no mobile equivalent.
+- **Multi-account / multi-instance.** One JIRA base URL + token per vault.
+- **Live Preview decorations beyond hover preview.** No inline status pills, no in-editor issue summaries, no CodeMirror widgets — hover-only.
+- **Telemetry.** No analytics, no crash reporting, no phone-home.
+
 ## Status
 
 v0.2: Smart link insertion on top of v0.1 foundation.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "JIRA Bases",
   "version": "0.6.0",
   "minAppVersion": "1.5.0",
-  "description": "JIRA Data Center integration for smart links, Bases metadata, and issue lookup.",
+  "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",
   "isDesktopOnly": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -93,7 +93,7 @@ export class JiraBasesSettingTab extends PluginSettingTab {
 
     const scopeNote = containerEl.createEl("p", { cls: "setting-item-description" });
     scopeNote.setText(
-      "Scope: JIRA Data Center / Server only (no Cloud), PAT auth (no OAuth), desktop only. " +
+      "Scope: JIRA Data Center only (no Cloud), PAT auth (no OAuth), desktop only. " +
         "One JIRA instance per vault. No telemetry.",
     );
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -91,6 +91,12 @@ export class JiraBasesSettingTab extends PluginSettingTab {
 
     containerEl.createEl("h2", { text: "JIRA Bases" });
 
+    const scopeNote = containerEl.createEl("p", { cls: "setting-item-description" });
+    scopeNote.setText(
+      "Scope: JIRA Data Center / Server only (no Cloud), PAT auth (no OAuth), desktop only. " +
+        "One JIRA instance per vault. No telemetry.",
+    );
+
     const urlSetting = new Setting(containerEl)
       .setName("JIRA base URL")
       .setDesc("e.g. https://jira.me.com (no trailing slash required)");


### PR DESCRIPTION
## Summary

Documents the plugin's non-goals across the three surfaces a user encounters it: the community-plugins listing, the README, and the in-app settings tab. Pure docs/clarification — no runtime behavior change.

- `manifest.json` description: extended with PAT-only desktop scope and an explicit "Not for JIRA Cloud" disclaimer
- `README.md`: new top-level `## Non-goals` section covering JIRA Cloud, OAuth, mobile, multi-account, Live Preview decorations beyond hover, and telemetry
- `src/settings.ts`: one-paragraph scope disclaimer at the top of the JIRA Bases settings tab
- Patch version bump `0.6.0` → `0.6.1` in lockstep across `manifest.json` and `package.json`

Trimmed two non-goal entries during drafting ("writing back to JIRA", "scheduled background sync") after re-reading source: `src/jira-client.ts` POSTs to `/issue/{key}/comment` and `src/main.ts` registers an interval-based stub auto-refresh — both would have been factually wrong as non-goals.

Closes #15.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — all 240 tests pass (22 files)
- [x] `npm run build` — production build succeeds
- [ ] Manual: open settings tab in a dev vault, confirm scope paragraph renders under the "JIRA Bases" heading and above the URL field
- [ ] Manual: skim README rendering on GitHub — Non-goals section sits between Summary and Status

🤖 Generated with [Claude Code](https://claude.com/claude-code)