### PR TITLE
JB-9: add BRAT install path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,21 @@ Three flows you'll use most:
 
 ## Quick start
 
-### 1. Install (dev / from source)
+### 1. Install via BRAT (recommended)
+
+JIRA Bases is not yet in Obsidian's community-plugin catalog (see [Community catalog](#community-catalog)). The recommended install path is [BRAT](https://github.com/TfTHacker/obsidian42-brat) — *Beta Reviewer's Auto-update Tool* — which installs and auto-updates plugins straight from a GitHub release.
+
+1. Install **Obsidian42 - BRAT** from *Settings → Community plugins → Browse* (search "BRAT") and enable it.
+2. Open the command palette and run **BRAT: Add a beta plugin for testing** (or *Settings → BRAT → Beta Plugin List → Add Beta plugin*).
+3. Paste the repository URL: `https://github.com/earchibald/jira-bases`
+4. Leave the version selector on *Latest version* and click **Add Plugin**. BRAT downloads `manifest.json` + `main.js` from the most recent [GitHub release](https://github.com/earchibald/jira-bases/releases) into `<vault>/.obsidian/plugins/jira-bases/`.
+5. Enable **JIRA Bases** under *Settings → Community plugins*.
+
+BRAT will check for new releases on Obsidian startup (and on demand via *BRAT: Check for updates to all beta plugins*) and update jira-bases in place.
+
+### 1b. Install from source (for plugin developers)
+
+If you're contributing or running an unreleased build:
 
 ```bash
 git clone https://github.com/earchibald/jira-bases.git
@@ -183,3 +197,7 @@ To keep scope tight, this plugin explicitly **does not** support:
 - **Multi-account / multi-instance.** One JIRA base URL + token per vault.
 - **Live Preview decorations beyond hover preview.** No inline status pills, no in-editor issue summaries, no CodeMirror widgets — hover-only.
 - **Telemetry.** No analytics, no crash reporting, no phone-home.
+
+### Community catalog
+
+JIRA Bases is **not** in Obsidian's community-plugin catalog yet, and submission is deferred until past `1.0.0`. The catalog reaches every Obsidian user, and several of the [Non-goals](#non-goals) above (no Cloud, no OAuth, no mobile, no multi-account) are common requests from a general audience — submitting before the surface is stable invites scope-creep pressure on a deliberately narrow plugin. Plan: ship `1.0.0` once the command and frontmatter surface have held steady across at least one minor release, then submit. Until then, install via [BRAT](#1-install-via-brat-recommended).

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds a recommended **Install via BRAT** subsection to the README (paste `https://github.com/earchibald/jira-bases`, BRAT pulls the existing GitHub release artifacts).
- Demotes the existing source-build subsection to *for plugin developers*.
- Adds a **Community catalog** subsection under Non-goals recording the deferral decision (defer past 1.0.0; references JB-12 narrow-scope rationale).
- Patch bump 0.6.2 → 0.6.3 in lockstep across `manifest.json` and `package.json`. Also resyncs `package-lock.json`'s top-level version (had drifted to 0.6.1 across earlier bumps).

Pure docs / metadata change. No source, no tests, no new dependencies, no public-API surface change.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 240/240 passing across 22 files
- [ ] Manual smoke on a fresh vault: install BRAT → paste repo URL → enable JIRA Bases (BRAT UI labels can drift; copy is intentionally generic but worth a sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)