### PR TITLE
JB-14: confirm before overwriting Generate Bases view output

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {

--- a/src/integration-base-generator.test.ts
+++ b/src/integration-base-generator.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { generateBase, type BaseConfig } from "./base-generator";
 import { VaultAdapter } from "./stub-writer";
+import { nextAvailablePath } from "./path-utils";
+
+type OverwriteChoice = "overwrite" | "save-as-new" | "cancel";
 
 function inMemoryVault(initial: Record<string, string> = {}): VaultAdapter & {
   files: Map<string, string>;
@@ -31,7 +34,8 @@ async function runEndToEndFlow(
   columns: string[],
   stubsFolder: string,
   viewName?: string,
-): Promise<{ success: boolean; error?: string }> {
+  onCollision: () => OverwriteChoice = () => "overwrite",
+): Promise<{ success: boolean; error?: string; writtenPath?: string; cancelled?: boolean }> {
   if (columns.length === 0) {
     return { success: false, error: "Select at least one column." };
   }
@@ -43,8 +47,15 @@ async function runEndToEndFlow(
   const normalizedFolder = stubsFolder.replace(/\/+$/, "");
   const baseFilePath = `${normalizedFolder}/JIRA Issues.base`;
   try {
-    await vault.write(baseFilePath, baseContent);
-    return { success: true };
+    let target = baseFilePath;
+    if (await vault.exists(baseFilePath)) {
+      const altPath = await nextAvailablePath(vault, baseFilePath);
+      const choice = onCollision();
+      if (choice === "cancel") return { success: true, cancelled: true };
+      target = choice === "save-as-new" ? altPath : baseFilePath;
+    }
+    await vault.write(target, baseContent);
+    return { success: true, writtenPath: target };
   } catch (e) {
     return { success: false, error: (e as Error).message };
   }
@@ -76,17 +87,85 @@ describe("integration: base generator end-to-end", () => {
     expect(vault.files.has("JIRA/JIRA Issues.base")).toBe(false);
   });
 
-  it("overwrites existing base file", async () => {
+  it("overwrites existing base file when user confirms overwrite", async () => {
     const vault = inMemoryVault({
       "JIRA/JIRA Issues.base": "old content",
     });
-    const result = await runEndToEndFlow(vault, ["key", "summary"], "JIRA");
+    const result = await runEndToEndFlow(
+      vault,
+      ["key", "summary"],
+      "JIRA",
+      undefined,
+      () => "overwrite",
+    );
 
     expect(result.success).toBe(true);
+    expect(result.writtenPath).toBe("JIRA/JIRA Issues.base");
     const baseContent = vault.files.get("JIRA/JIRA Issues.base")!;
     expect(baseContent).not.toContain("old content");
     expect(baseContent).toContain("- jira_key");
     expect(baseContent).toContain("- jira_summary");
+  });
+
+  it("does not write when the user cancels the overwrite prompt", async () => {
+    const vault = inMemoryVault({
+      "JIRA/JIRA Issues.base": "old content",
+    });
+    const result = await runEndToEndFlow(
+      vault,
+      ["key", "summary"],
+      "JIRA",
+      undefined,
+      () => "cancel",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.cancelled).toBe(true);
+    expect(result.writtenPath).toBeUndefined();
+    expect(vault.files.get("JIRA/JIRA Issues.base")).toBe("old content");
+    expect(vault.files.has("JIRA/JIRA Issues (1).base")).toBe(false);
+  });
+
+  it("writes to a disambiguated path when the user picks 'save as new'", async () => {
+    const vault = inMemoryVault({
+      "JIRA/JIRA Issues.base": "old content",
+    });
+    const result = await runEndToEndFlow(
+      vault,
+      ["key", "summary"],
+      "JIRA",
+      undefined,
+      () => "save-as-new",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.writtenPath).toBe("JIRA/JIRA Issues (1).base");
+    expect(vault.files.get("JIRA/JIRA Issues.base")).toBe("old content");
+    const altContent = vault.files.get("JIRA/JIRA Issues (1).base")!;
+    expect(altContent).toContain("- jira_key");
+    expect(altContent).toContain("- jira_summary");
+  });
+
+  it("walks past existing disambiguated paths when picking 'save as new'", async () => {
+    const vault = inMemoryVault({
+      "JIRA/JIRA Issues.base": "old content",
+      "JIRA/JIRA Issues (1).base": "alt 1",
+      "JIRA/JIRA Issues (2).base": "alt 2",
+    });
+    const result = await runEndToEndFlow(
+      vault,
+      ["key"],
+      "JIRA",
+      undefined,
+      () => "save-as-new",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.writtenPath).toBe("JIRA/JIRA Issues (3).base");
+    expect(vault.files.get("JIRA/JIRA Issues.base")).toBe("old content");
+    expect(vault.files.get("JIRA/JIRA Issues (1).base")).toBe("alt 1");
+    expect(vault.files.get("JIRA/JIRA Issues (2).base")).toBe("alt 2");
+    expect(vault.files.has("JIRA/JIRA Issues (3).base")).toBe(true);
   });
 
   it("uses custom view name when provided", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,8 @@ import {
 } from "./indexer";
 import { writeStub, VaultAdapter } from "./stub-writer";
 import { ConfirmModal } from "./confirm-modal";
+import { OverwriteModal } from "./overwrite-modal";
+import { nextAvailablePath } from "./path-utils";
 import { createIssueCache } from "./issue-cache";
 import { createIssueService, IssueService } from "./issue-service";
 import { registerHoverPreview } from "./hover-preview";
@@ -697,10 +699,28 @@ export default class JiraBasesPlugin extends Plugin {
       const vault = this.makeVaultAdapter();
       const stubsFolder = this.settings.stubsFolder.replace(/^\/+|\/+$/g, "");
       const baseFilePath = stubsFolder ? `${stubsFolder}/JIRA Issues.base` : `JIRA Issues.base`;
+
+      const writeAt = async (path: string) => {
+        try {
+          if (stubsFolder) await vault.ensureFolder(stubsFolder);
+          await vault.write(path, baseContent);
+          new Notice(`Bases view created at ${path}`);
+        } catch (e) {
+          new Notice(`Failed to create view: ${(e as Error).message}`);
+        }
+      };
+
       try {
-        if (stubsFolder) await vault.ensureFolder(stubsFolder);
-        await vault.write(baseFilePath, baseContent);
-        new Notice(`Bases view created at ${baseFilePath}`);
+        if (await vault.exists(baseFilePath)) {
+          const altPath = await nextAvailablePath(vault, baseFilePath);
+          new OverwriteModal(this.app, baseFilePath, altPath, {
+            onOverwrite: () => void writeAt(baseFilePath),
+            onSaveAsNew: () => void writeAt(altPath),
+            onCancel: () => new Notice("Bases view creation cancelled."),
+          }).open();
+          return;
+        }
+        await writeAt(baseFilePath);
       } catch (e) {
         new Notice(`Failed to create view: ${(e as Error).message}`);
       }

--- a/src/overwrite-modal.test.ts
+++ b/src/overwrite-modal.test.ts
@@ -111,4 +111,19 @@ describe("OverwriteModal", () => {
     modal.onClose();
     expect(modal.contentEl.children.length).toBe(0);
   });
+
+  it("calls onCancel when closed without clicking a button (e.g., ESC key)", () => {
+    const { modal, onCancel } = makeModal();
+    modal.onOpen();
+    modal.onClose();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel only once even if onClose is invoked twice", () => {
+    const { modal, onCancel } = makeModal();
+    modal.onOpen();
+    modal.onClose();
+    modal.onClose();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/overwrite-modal.test.ts
+++ b/src/overwrite-modal.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { OverwriteModal } from "./overwrite-modal";
+
+function makeModal(opts: Partial<{
+  onOverwrite: () => void;
+  onSaveAsNew: () => void;
+  onCancel: () => void;
+  existingPath: string;
+  alternatePath: string;
+}> = {}) {
+  const onOverwrite = opts.onOverwrite ?? vi.fn();
+  const onSaveAsNew = opts.onSaveAsNew ?? vi.fn();
+  const onCancel = opts.onCancel ?? vi.fn();
+  const modal = new OverwriteModal(
+    {} as any,
+    opts.existingPath ?? "JIRA/JIRA Issues.base",
+    opts.alternatePath ?? "JIRA/JIRA Issues (1).base",
+    { onOverwrite, onSaveAsNew, onCancel },
+  );
+  return { modal, onOverwrite, onSaveAsNew, onCancel };
+}
+
+function buttonByText(modal: OverwriteModal, text: string): HTMLButtonElement {
+  const btns = modal.contentEl.querySelectorAll("button");
+  const match = Array.from(btns).find((b) => b.textContent === text);
+  if (!match) throw new Error(`No button with text "${text}"`);
+  return match as HTMLButtonElement;
+}
+
+describe("OverwriteModal", () => {
+  it("renders the existing path and the alternate path in the body", () => {
+    const { modal } = makeModal({
+      existingPath: "Foo/JIRA Issues.base",
+      alternatePath: "Foo/JIRA Issues (3).base",
+    });
+    modal.onOpen();
+    const text = modal.contentEl.textContent ?? "";
+    expect(text).toContain("Foo/JIRA Issues.base");
+    expect(text).toContain("Foo/JIRA Issues (3).base");
+  });
+
+  it("sets the title", () => {
+    const { modal } = makeModal();
+    modal.onOpen();
+    expect(modal.titleEl.textContent).toBe("File already exists");
+  });
+
+  it("renders three buttons: Cancel, Overwrite, Save as new", () => {
+    const { modal } = makeModal();
+    modal.onOpen();
+    const labels = Array.from(modal.contentEl.querySelectorAll("button")).map(
+      (b) => b.textContent,
+    );
+    expect(labels).toEqual(["Cancel", "Overwrite", "Save as new"]);
+  });
+
+  it("calls onOverwrite and closes when Overwrite is clicked", () => {
+    const { modal, onOverwrite, onSaveAsNew, onCancel } = makeModal();
+    const closeSpy = vi.spyOn(modal, "close");
+    modal.onOpen();
+    buttonByText(modal, "Overwrite").click();
+    expect(onOverwrite).toHaveBeenCalledTimes(1);
+    expect(onSaveAsNew).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("calls onSaveAsNew and closes when Save as new is clicked", () => {
+    const { modal, onOverwrite, onSaveAsNew, onCancel } = makeModal();
+    const closeSpy = vi.spyOn(modal, "close");
+    modal.onOpen();
+    buttonByText(modal, "Save as new").click();
+    expect(onSaveAsNew).toHaveBeenCalledTimes(1);
+    expect(onOverwrite).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("calls onCancel and closes when Cancel is clicked", () => {
+    const { modal, onOverwrite, onSaveAsNew, onCancel } = makeModal();
+    const closeSpy = vi.spyOn(modal, "close");
+    modal.onOpen();
+    buttonByText(modal, "Cancel").click();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onOverwrite).not.toHaveBeenCalled();
+    expect(onSaveAsNew).not.toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("tolerates a missing onCancel callback", () => {
+    const modal = new OverwriteModal({} as any, "a.base", "a (1).base", {
+      onOverwrite: vi.fn(),
+      onSaveAsNew: vi.fn(),
+    });
+    modal.onOpen();
+    expect(() => buttonByText(modal, "Cancel").click()).not.toThrow();
+  });
+
+  it("Save as new is the CTA button", () => {
+    const { modal } = makeModal();
+    modal.onOpen();
+    const cta = modal.contentEl.querySelector('button[class*="mod-cta"]');
+    expect(cta?.textContent).toBe("Save as new");
+  });
+
+  it("clears content on close", () => {
+    const { modal } = makeModal();
+    modal.onOpen();
+    expect(modal.contentEl.children.length).toBeGreaterThan(0);
+    modal.onClose();
+    expect(modal.contentEl.children.length).toBe(0);
+  });
+});

--- a/src/overwrite-modal.ts
+++ b/src/overwrite-modal.ts
@@ -1,0 +1,59 @@
+import { App, Modal, Setting } from "obsidian";
+
+export interface OverwriteModalCallbacks {
+  onOverwrite: () => void;
+  onSaveAsNew: () => void;
+  onCancel?: () => void;
+}
+
+export class OverwriteModal extends Modal {
+  constructor(
+    app: App,
+    private existingPath: string,
+    private alternatePath: string,
+    private callbacks: OverwriteModalCallbacks,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl, titleEl } = this;
+    titleEl.setText("File already exists");
+
+    contentEl.createEl("p", {
+      text: `A file already exists at "${this.existingPath}". What would you like to do?`,
+    });
+    contentEl.createEl("p", { text: "Overwrite: replace the existing file." });
+    contentEl.createEl("p", {
+      text: `Save as new: write to "${this.alternatePath}" instead.`,
+    });
+    contentEl.createEl("p", { text: "Cancel: do nothing." });
+
+    new Setting(contentEl)
+      .addButton((btn) =>
+        btn.setButtonText("Cancel").onClick(() => {
+          this.close();
+          this.callbacks.onCancel?.();
+        }),
+      )
+      .addButton((btn) =>
+        btn.setButtonText("Overwrite").onClick(() => {
+          this.close();
+          this.callbacks.onOverwrite();
+        }),
+      )
+      .addButton((btn) =>
+        btn
+          .setButtonText("Save as new")
+          .setCta()
+          .onClick(() => {
+            this.close();
+            this.callbacks.onSaveAsNew();
+          }),
+      );
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/overwrite-modal.ts
+++ b/src/overwrite-modal.ts
@@ -7,6 +7,8 @@ export interface OverwriteModalCallbacks {
 }
 
 export class OverwriteModal extends Modal {
+  private resolved = false;
+
   constructor(
     app: App,
     private existingPath: string,
@@ -32,12 +34,14 @@ export class OverwriteModal extends Modal {
     new Setting(contentEl)
       .addButton((btn) =>
         btn.setButtonText("Cancel").onClick(() => {
+          this.resolved = true;
           this.close();
           this.callbacks.onCancel?.();
         }),
       )
       .addButton((btn) =>
         btn.setButtonText("Overwrite").onClick(() => {
+          this.resolved = true;
           this.close();
           this.callbacks.onOverwrite();
         }),
@@ -47,6 +51,7 @@ export class OverwriteModal extends Modal {
           .setButtonText("Save as new")
           .setCta()
           .onClick(() => {
+            this.resolved = true;
             this.close();
             this.callbacks.onSaveAsNew();
           }),
@@ -54,6 +59,10 @@ export class OverwriteModal extends Modal {
   }
 
   onClose(): void {
+    if (!this.resolved) {
+      this.resolved = true;
+      this.callbacks.onCancel?.();
+    }
     this.contentEl.empty();
   }
 }

--- a/src/path-utils.test.ts
+++ b/src/path-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { nextAvailablePath, splitExtension, type ExistsAdapter } from "./path-utils";
+
+function fakeVault(existing: Set<string>): ExistsAdapter {
+  return { async exists(p) { return existing.has(p); } };
+}
+
+describe("splitExtension", () => {
+  it("splits at the last dot", () => {
+    expect(splitExtension("JIRA Issues.base")).toEqual({
+      stem: "JIRA Issues",
+      ext: ".base",
+    });
+  });
+
+  it("treats files without an extension as stem-only", () => {
+    expect(splitExtension("README")).toEqual({ stem: "README", ext: "" });
+  });
+
+  it("does not split on dots in directory names", () => {
+    expect(splitExtension("dir.name/file")).toEqual({
+      stem: "dir.name/file",
+      ext: "",
+    });
+  });
+
+  it("preserves directory paths in stem", () => {
+    expect(splitExtension("a/b/c.ext")).toEqual({ stem: "a/b/c", ext: ".ext" });
+  });
+
+  it("treats hidden dotfiles as having no extension", () => {
+    expect(splitExtension(".gitignore")).toEqual({
+      stem: ".gitignore",
+      ext: "",
+    });
+  });
+});
+
+describe("nextAvailablePath", () => {
+  it("returns the original path when nothing collides", async () => {
+    const vault = fakeVault(new Set());
+    expect(await nextAvailablePath(vault, "JIRA/JIRA Issues.base")).toBe(
+      "JIRA/JIRA Issues.base",
+    );
+  });
+
+  it("walks (1), (2), … until it finds an unused name", async () => {
+    const vault = fakeVault(
+      new Set([
+        "JIRA/JIRA Issues.base",
+        "JIRA/JIRA Issues (1).base",
+        "JIRA/JIRA Issues (2).base",
+      ]),
+    );
+    expect(await nextAvailablePath(vault, "JIRA/JIRA Issues.base")).toBe(
+      "JIRA/JIRA Issues (3).base",
+    );
+  });
+
+  it("returns (1) when only the original collides", async () => {
+    const vault = fakeVault(new Set(["JIRA Issues.base"]));
+    expect(await nextAvailablePath(vault, "JIRA Issues.base")).toBe(
+      "JIRA Issues (1).base",
+    );
+  });
+
+  it("preserves the extension in the disambiguated filename", async () => {
+    const vault = fakeVault(new Set(["x/y.base"]));
+    expect(await nextAvailablePath(vault, "x/y.base")).toBe("x/y (1).base");
+  });
+
+  it("handles extensionless paths", async () => {
+    const vault = fakeVault(new Set(["dir/README", "dir/README (1)"]));
+    expect(await nextAvailablePath(vault, "dir/README")).toBe(
+      "dir/README (2)",
+    );
+  });
+
+  it("throws after the disambiguation cap to avoid infinite loops", async () => {
+    const vault: ExistsAdapter = { async exists() { return true; } };
+    await expect(nextAvailablePath(vault, "x.base")).rejects.toThrow(
+      /Could not find an available filename/,
+    );
+  });
+});

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -1,0 +1,30 @@
+export interface ExistsAdapter {
+  exists(path: string): Promise<boolean>;
+}
+
+const MAX_DISAMBIGUATION_ATTEMPTS = 1000;
+
+export function splitExtension(path: string): { stem: string; ext: string } {
+  const lastSlash = path.lastIndexOf("/");
+  const dot = path.lastIndexOf(".");
+  // Hidden dotfiles (dot is the first char of the basename) have no extension.
+  if (dot <= lastSlash + 1 || dot === -1) {
+    return { stem: path, ext: "" };
+  }
+  return { stem: path.slice(0, dot), ext: path.slice(dot) };
+}
+
+export async function nextAvailablePath(
+  vault: ExistsAdapter,
+  path: string,
+): Promise<string> {
+  if (!(await vault.exists(path))) return path;
+  const { stem, ext } = splitExtension(path);
+  for (let n = 1; n <= MAX_DISAMBIGUATION_ATTEMPTS; n++) {
+    const candidate = `${stem} (${n})${ext}`;
+    if (!(await vault.exists(candidate))) return candidate;
+  }
+  throw new Error(
+    `Could not find an available filename after ${MAX_DISAMBIGUATION_ATTEMPTS} attempts for ${path}`,
+  );
+}


### PR DESCRIPTION
## Summary

- The `JIRA: Generate Bases view` command previously called `vault.write` unconditionally, silently overwriting any user customisations on re-run (`vault.write` falls back to `vault.modify` when the file exists).
- Now check `vault.exists` first; if the target collides, open a three-button modal (`Cancel` / `Overwrite` / `Save as new`). `Save as new` writes to the next available `JIRA Issues (N).base` via a new pure helper.
- New: `src/path-utils.ts` (collision walker), `src/overwrite-modal.ts` (three-button modal), with unit + integration test coverage.

## Test plan

- [x] `npm test` — 263 pass (24 files), including 11 new `path-utils` tests, 9 new `OverwriteModal` tests, and 4 new branches in the integration test (overwrite-confirm, cancel, save-as-new, walk-past-existing).
- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [ ] Manual smoke: re-run `JIRA: Generate Bases view` against a customised `JIRA Issues.base`, confirm the prompt fires and Cancel preserves the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)