### PR TITLE
JB-11: sync UX — failure log, scoped sync, status-bar interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to **JIRA Bases** are recorded here. Releases follow [semver](https://semver.org/) and are auto-published to GitHub Releases when `manifest.json` / `package.json` versions change on `main`.
 
+## 0.8.0 — Sync UX: failure log, scoped sync, status-bar interaction (JB-11)
+
+- **Inspectable failure log.** When a sync ends with failures, the Notice now invites a click that opens a modal listing every failure (key, error kind, full message) plus the synced count and timestamp. Replaces the prior "Synced N stubs (M failed). First: …" Notice that only surfaced one failure.
+- **Scoped sync commands.** Three new commands let you refresh stubs without re-scanning the whole vault:
+  - **JIRA: Sync this note's references** — scans the active file only.
+  - **JIRA: Sync this folder's references** — scans every `.md` under the active note's folder (recursive).
+  - **JIRA: Sync this issue** — single-key prompt; auto-fills from the cursor when a JIRA key is under it.
+- **Clickable status bar.** The "JIRA: Last synced …" status-bar item is now interactive — click to reopen the last sync's failure log. Same surface is also available as the **JIRA: Show last sync summary** command for keyboard-only users.
+
 ## 0.6.2 — README rewrite (JB-7)
 
 - README rewritten as a user-facing reference (Overview / Quick Start / Reference / Troubleshooting / Non-goals). Per-version blocks moved here. Corrected the PAT-storage description: the token is encrypted with Electron `safeStorage` (using OS-managed keys) and the base64 ciphertext is stored in `<vault>/.obsidian/plugins/jira-bases/data.json` — not in the OS keychain directly.

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -25,33 +25,47 @@ export class PluginSettingTab {
   display() {}
 }
 
+function augmentElement(el: any): any {
+  el.empty = function () {
+    this.innerHTML = "";
+  };
+  el.setText = function (text: string) {
+    this.textContent = text;
+  };
+  el.addClass = function (cls: string) {
+    this.classList.add(cls);
+  };
+  el.createEl = function (tag: string, options?: any) {
+    const child = document.createElement(tag);
+    if (options?.text) {
+      child.textContent = options.text;
+    }
+    if (options?.cls) {
+      const classes = Array.isArray(options.cls) ? options.cls : [options.cls];
+      for (const c of classes) child.classList.add(c);
+    }
+    augmentElement(child);
+    this.appendChild(child);
+    return child;
+  };
+  el.createDiv = function (options?: any) {
+    return el.createEl("div", options);
+  };
+  return el;
+}
+
 export class Modal {
   app: unknown;
-  contentEl: HTMLElement & { empty: () => void; createEl: (tag: string, options?: any) => HTMLElement };
+  contentEl: HTMLElement & {
+    empty: () => void;
+    createEl: (tag: string, options?: any) => HTMLElement;
+  };
   titleEl: HTMLElement & { setText: (text: string) => void };
 
   constructor(app: unknown) {
     this.app = app;
-
-    const contentEl = document.createElement("div") as any;
-    contentEl.empty = function () {
-      this.innerHTML = "";
-    };
-    contentEl.createEl = function (tag: string, options?: any) {
-      const el = document.createElement(tag);
-      if (options?.text) {
-        el.textContent = options.text;
-      }
-      this.appendChild(el);
-      return el;
-    };
-    this.contentEl = contentEl;
-
-    const titleEl = document.createElement("div") as any;
-    titleEl.setText = function (text: string) {
-      this.textContent = text;
-    };
-    this.titleEl = titleEl;
+    this.contentEl = augmentElement(document.createElement("div"));
+    this.titleEl = augmentElement(document.createElement("div"));
   }
 
   open() {}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {

--- a/src/indexer.test.ts
+++ b/src/indexer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   collectAllKeys,
+  collectKeysInPaths,
   findOrphanedStubs,
   IndexerDeps,
 } from "./indexer";
@@ -88,6 +89,49 @@ describe("collectAllKeys", () => {
     });
     // Leading slash should be stripped; stub must still be excluded.
     const keys = await collectAllKeys(d, "/JIRA");
+    expect([...keys]).toEqual(["ABC-1"]);
+  });
+});
+
+describe("collectKeysInPaths", () => {
+  it("scans only the supplied paths", async () => {
+    const d = deps({
+      "a.md": "ref [t](https://jira.me.com/browse/ABC-1)\n",
+      "b.md": "ref [t](https://jira.me.com/browse/ABC-2)\n",
+      "c.md": "ref [t](https://jira.me.com/browse/ABC-3)\n",
+    });
+    const keys = await collectKeysInPaths(d, ["a.md", "b.md"], "JIRA");
+    expect([...keys].sort()).toEqual(["ABC-1", "ABC-2"]);
+  });
+
+  it("excludes paths inside the stubs folder even when explicitly listed", async () => {
+    const d = deps({
+      "user.md": "ref [t](https://jira.me.com/browse/ABC-1)\n",
+      "JIRA/ABC-9 stub.md":
+        "ref [t](https://jira.me.com/browse/SHOULD-NOT-COUNT-1)\n",
+    });
+    const keys = await collectKeysInPaths(
+      d,
+      ["user.md", "JIRA/ABC-9 stub.md"],
+      "JIRA",
+    );
+    expect([...keys].sort()).toEqual(["ABC-1"]);
+  });
+
+  it("returns empty when neither baseUrl nor prefixes are configured", async () => {
+    const d = deps(
+      { "a.md": "ABC-1 in the body\n" },
+      { baseUrl: "", prefixes: [], stubsFolder: "JIRA" },
+    );
+    const keys = await collectKeysInPaths(d, ["a.md"], "JIRA");
+    expect([...keys]).toEqual([]);
+  });
+
+  it("silently skips paths that don't exist", async () => {
+    const d = deps({
+      "a.md": "ref [t](https://jira.me.com/browse/ABC-1)\n",
+    });
+    const keys = await collectKeysInPaths(d, ["a.md", "missing.md"], "JIRA");
     expect([...keys]).toEqual(["ABC-1"]);
   });
 });

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -15,16 +15,23 @@ export async function collectAllKeys(
   deps: IndexerDeps,
   stubsFolder: string,
 ): Promise<Set<string>> {
+  const notes = await deps.listNotes();
+  return collectKeysInPaths(deps, notes, stubsFolder);
+}
+
+export async function collectKeysInPaths(
+  deps: IndexerDeps,
+  paths: Iterable<string>,
+  stubsFolder: string,
+): Promise<Set<string>> {
   const { baseUrl, prefixes } = deps.getSettings();
   const keys = new Set<string>();
-  // Fast path: nothing can ever match when both sources of key patterns are absent.
   const normalizedBase = baseUrl.replace(/\/+$/, "");
   const validPrefixes = prefixes.filter((p) => /^[A-Z][A-Z0-9]+$/.test(p));
   if (normalizedBase.length === 0 && validPrefixes.length === 0) return keys;
-  const notes = await deps.listNotes();
-  const prefix = stubsFolder.replace(/^\/+|\/+$/, "") + "/";
-  for (const path of notes) {
-    if (path.startsWith(prefix)) continue;
+  const stubPrefix = stubsFolder.replace(/^\/+|\/+$/, "") + "/";
+  for (const path of paths) {
+    if (path.startsWith(stubPrefix)) continue;
     const content = await deps.read(path);
     if (content === null) continue;
     const { body } = readFrontmatter(content);

--- a/src/main.ts
+++ b/src/main.ts
@@ -408,6 +408,11 @@ export default class JiraBasesPlugin extends Plugin {
       }
     }
 
+    const failureCount = this.lastSyncSummary?.failures.length ?? 0;
+    if (failureCount > 0) {
+      parts.push(`${failureCount} failed`);
+    }
+
     this.statusBarItem.setText(parts.join(" | "));
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {
 } from "./auto-lookup";
 import {
   collectAllKeys,
+  collectKeysInPaths,
   findOrphanedStubs,
   listStubPaths,
   IndexerDeps,
@@ -44,6 +45,8 @@ import {
 } from "./jira-key";
 import { CommentIssueSuggestModal } from "./comment-issue-modal";
 import { createFailedKeysTracker, FailedKeysTracker } from "./failed-keys-tracker";
+import { SyncFailure, SyncFailuresModal, SyncSummary } from "./sync-failures-modal";
+import { SyncIssueModal } from "./sync-issue-modal";
 import type { Editor } from "obsidian";
 import { generateBase } from "./base-generator";
 import { BaseGeneratorModal } from "./base-generator-modal";
@@ -107,6 +110,7 @@ export default class JiraBasesPlugin extends Plugin {
   private autoRefreshIntervalId: number | null = null;
   private statusBarItem: HTMLElement | null = null;
   private lastSyncTimestamp: number | null = null;
+  private lastSyncSummary: SyncSummary | null = null;
   private statusBarUpdateIntervalId: number | null = null;
 
   recreateFailedKeysTracker(): void {
@@ -145,6 +149,30 @@ export default class JiraBasesPlugin extends Plugin {
       id: "sync-issue-stubs",
       name: "JIRA: Sync issue stubs",
       callback: () => this.syncIssueStubs(),
+    });
+
+    this.addCommand({
+      id: "sync-this-note",
+      name: "JIRA: Sync this note's references",
+      callback: () => this.syncThisNote(),
+    });
+
+    this.addCommand({
+      id: "sync-this-folder",
+      name: "JIRA: Sync this folder's references",
+      callback: () => this.syncThisFolder(),
+    });
+
+    this.addCommand({
+      id: "sync-this-issue",
+      name: "JIRA: Sync this issue",
+      callback: () => this.syncThisIssue(),
+    });
+
+    this.addCommand({
+      id: "show-last-sync-summary",
+      name: "JIRA: Show last sync summary",
+      callback: () => this.showLastSyncSummary(),
     });
 
     this.addCommand({
@@ -333,6 +361,9 @@ export default class JiraBasesPlugin extends Plugin {
 
     if (!this.statusBarItem) {
       this.statusBarItem = this.addStatusBarItem();
+      this.statusBarItem.addClass("mod-clickable");
+      this.statusBarItem.setAttribute("aria-label", "Show last JIRA sync summary");
+      this.statusBarItem.addEventListener("click", () => this.showLastSyncSummary());
     }
 
     this.updateStatusBar();
@@ -609,21 +640,112 @@ export default class JiraBasesPlugin extends Plugin {
       return;
     }
     const deps = this.makeIndexerDeps();
-    const vault = this.makeVaultAdapter();
-    const client = this.makeClient();
     const keys = [...(await collectAllKeys(deps, this.settings.stubsFolder))];
     if (keys.length === 0) {
       new Notice("No JIRA references found in vault.");
       return;
     }
+    await this.syncKeys(keys, "vault");
+  }
+
+  async syncThisNote(): Promise<void> {
+    if (!this.settings.baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+    const file = this.app.workspace.getActiveFile();
+    if (!file) {
+      new Notice("Open a note before running JIRA: Sync this note's references.");
+      return;
+    }
+    const deps = this.makeIndexerDeps();
+    const keys = [
+      ...(await collectKeysInPaths(deps, [file.path], this.settings.stubsFolder)),
+    ];
+    if (keys.length === 0) {
+      new Notice(`No JIRA references found in ${file.path}.`);
+      return;
+    }
+    await this.syncKeys(keys, file.path);
+  }
+
+  async syncThisFolder(): Promise<void> {
+    if (!this.settings.baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+    const file = this.app.workspace.getActiveFile();
+    if (!file) {
+      new Notice("Open a note inside the folder you want to sync.");
+      return;
+    }
+    const folder = file.parent;
+    if (!(folder instanceof TFolder)) {
+      new Notice("Active note is not inside a folder.");
+      return;
+    }
+    const paths: string[] = [];
+    const walk = (f: TFolder) => {
+      for (const child of f.children) {
+        if (child instanceof TFile && child.extension === "md") {
+          paths.push(child.path);
+        } else if (child instanceof TFolder) {
+          walk(child);
+        }
+      }
+    };
+    walk(folder);
+    if (paths.length === 0) {
+      new Notice(`No notes found under ${folder.path || "/"}.`);
+      return;
+    }
+    const deps = this.makeIndexerDeps();
+    const keys = [
+      ...(await collectKeysInPaths(deps, paths, this.settings.stubsFolder)),
+    ];
+    if (keys.length === 0) {
+      new Notice(`No JIRA references found under ${folder.path || "/"}.`);
+      return;
+    }
+    await this.syncKeys(keys, folder.path || "/");
+  }
+
+  async syncThisIssue(): Promise<void> {
+    if (!this.settings.baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+    const editor = this.app.workspace.activeEditor?.editor ?? null;
+    let prefilled = "";
+    if (editor) {
+      const cursor = editor.getCursor();
+      const hit = findKeyAtCol(editor.getLine(cursor.line), cursor.ch);
+      if (hit) prefilled = hit.key;
+    }
+    new SyncIssueModal(this.app, prefilled, this.settings.baseUrl, (key) => {
+      void this.syncKeys([key], `issue ${key}`);
+    }).open();
+  }
+
+  showLastSyncSummary(): void {
+    if (!this.lastSyncSummary) {
+      new Notice("JIRA: no sync has run yet in this session.");
+      return;
+    }
+    new SyncFailuresModal(this.app, this.lastSyncSummary).open();
+  }
+
+  private async syncKeys(keys: string[], scopeLabel: string): Promise<void> {
+    const deps = this.makeIndexerDeps();
+    const vault = this.makeVaultAdapter();
+    const client = this.makeClient();
     const existingByKey = await listStubPaths(deps, this.settings.stubsFolder);
     let synced = 0;
-    const failures: string[] = [];
+    const failures: SyncFailure[] = [];
     for (const key of keys) {
       const r = await client.getIssueDetails(key);
       if (!r.ok) {
-        const detail = errorMessage(r.error);
-        failures.push(`${key}: ${detail}`);
+        failures.push({ key, kind: r.error.kind, message: errorMessage(r.error) });
         console.warn(`jira-bases: ${key} — ${r.error.kind}`, r.error);
         continue;
       }
@@ -637,20 +759,28 @@ export default class JiraBasesPlugin extends Plugin {
         synced++;
       } catch (e) {
         const msg = (e as Error).message;
-        failures.push(`${key}: write failed — ${msg}`);
+        failures.push({ key, kind: "write", message: `write failed — ${msg}` });
         console.warn(`jira-bases: ${key} — write failed`, e);
       }
     }
-    this.lastSyncTimestamp = Date.now();
+    const timestamp = Date.now();
+    this.lastSyncTimestamp = timestamp;
+    this.lastSyncSummary = { scope: scopeLabel, synced, failures, timestamp };
     this.updateStatusBar();
+
     if (failures.length === 0) {
       new Notice(`Synced ${synced} stubs.`);
-    } else {
-      new Notice(
-        `Synced ${synced} stubs (${failures.length} failed).\nFirst: ${failures[0]}`,
-        10000,
-      );
+      return;
     }
+    const notice = new Notice(
+      `Synced ${synced} stubs (${failures.length} failed). Click for details.`,
+      10000,
+    );
+    notice.messageEl.addEventListener("click", () => {
+      if (this.lastSyncSummary) {
+        new SyncFailuresModal(this.app, this.lastSyncSummary).open();
+      }
+    });
   }
 
   async cleanOrphanedStubs(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,8 @@ export default class JiraBasesPlugin extends Plugin {
   private statusBarItem: HTMLElement | null = null;
   private lastSyncTimestamp: number | null = null;
   private lastSyncSummary: SyncSummary | null = null;
+  private lastSyncSummaryRunId: number = 0;
+  private nextSyncRunId: number = 1;
   private statusBarUpdateIntervalId: number | null = null;
 
   recreateFailedKeysTracker(): void {
@@ -736,6 +738,7 @@ export default class JiraBasesPlugin extends Plugin {
   }
 
   private async syncKeys(keys: string[], scopeLabel: string): Promise<void> {
+    const runId = this.nextSyncRunId++;
     const deps = this.makeIndexerDeps();
     const vault = this.makeVaultAdapter();
     const client = this.makeClient();
@@ -764,9 +767,14 @@ export default class JiraBasesPlugin extends Plugin {
       }
     }
     const timestamp = Date.now();
-    this.lastSyncTimestamp = timestamp;
-    this.lastSyncSummary = { scope: scopeLabel, synced, failures, timestamp };
-    this.updateStatusBar();
+    const summary: SyncSummary = { scope: scopeLabel, synced, failures, timestamp };
+    // Only update the stored summary if this is the latest run.
+    if (runId > this.lastSyncSummaryRunId) {
+      this.lastSyncTimestamp = timestamp;
+      this.lastSyncSummary = summary;
+      this.lastSyncSummaryRunId = runId;
+      this.updateStatusBar();
+    }
 
     if (failures.length === 0) {
       new Notice(`Synced ${synced} stubs.`);
@@ -776,11 +784,13 @@ export default class JiraBasesPlugin extends Plugin {
       `Synced ${synced} stubs (${failures.length} failed). Click for details.`,
       10000,
     );
-    notice.messageEl.addEventListener("click", () => {
-      if (this.lastSyncSummary) {
-        new SyncFailuresModal(this.app, this.lastSyncSummary).open();
-      }
-    });
+    // Close over the local summary, not this.lastSyncSummary, so the click shows the right result.
+    const messageEl = (notice as any).messageEl ?? (notice as any).noticeEl;
+    if (messageEl) {
+      messageEl.addEventListener("click", () => {
+        new SyncFailuresModal(this.app, summary).open();
+      });
+    }
   }
 
   async cleanOrphanedStubs(): Promise<void> {

--- a/src/sync-failures-modal.test.ts
+++ b/src/sync-failures-modal.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { SyncFailuresModal, SyncSummary } from "./sync-failures-modal";
+
+function summary(over: Partial<SyncSummary> = {}): SyncSummary {
+  return {
+    scope: "vault",
+    synced: 4,
+    failures: [],
+    timestamp: Date.parse("2026-01-15T10:00:00Z"),
+    ...over,
+  };
+}
+
+function buttonByText(modal: SyncFailuresModal, text: string): HTMLButtonElement {
+  const btns = modal.contentEl.querySelectorAll("button");
+  const match = Array.from(btns).find((b) => b.textContent === text);
+  if (!match) throw new Error(`No button with text "${text}"`);
+  return match as HTMLButtonElement;
+}
+
+describe("SyncFailuresModal", () => {
+  it("renders an empty-state message when there are no failures", () => {
+    const modal = new SyncFailuresModal({} as any, summary({ failures: [] }));
+    modal.onOpen();
+    expect(modal.titleEl.textContent).toBe("JIRA sync — last run");
+    expect(modal.contentEl.textContent).toContain("No failures in the last sync.");
+  });
+
+  it("lists every failure with its key, kind, and message", () => {
+    const modal = new SyncFailuresModal(
+      {} as any,
+      summary({
+        failures: [
+          { key: "ABC-1", kind: "auth", message: "Authentication failed (HTTP 401)." },
+          { key: "ABC-2", kind: "not-found", message: "Issue ABC-2 not found." },
+          { key: "ABC-3", kind: "write", message: "write failed — disk full" },
+        ],
+      }),
+    );
+    modal.onOpen();
+    const text = modal.contentEl.textContent ?? "";
+    expect(text).toContain("ABC-1");
+    expect(text).toContain("[auth]");
+    expect(text).toContain("Authentication failed");
+    expect(text).toContain("ABC-2");
+    expect(text).toContain("[not-found]");
+    expect(text).toContain("Issue ABC-2 not found.");
+    expect(text).toContain("ABC-3");
+    expect(text).toContain("[write]");
+    expect(text).toContain("write failed — disk full");
+  });
+
+  it("titles itself with the failure count", () => {
+    const one = new SyncFailuresModal(
+      {} as any,
+      summary({ failures: [{ key: "X-1", kind: "auth", message: "m" }] }),
+    );
+    one.onOpen();
+    expect(one.titleEl.textContent).toBe("JIRA sync — 1 failure");
+
+    const many = new SyncFailuresModal(
+      {} as any,
+      summary({
+        failures: [
+          { key: "X-1", kind: "auth", message: "m" },
+          { key: "X-2", kind: "auth", message: "m" },
+        ],
+      }),
+    );
+    many.onOpen();
+    expect(many.titleEl.textContent).toBe("JIRA sync — 2 failures");
+  });
+
+  it("renders the scope and synced count in the meta line", () => {
+    const modal = new SyncFailuresModal(
+      {} as any,
+      summary({ scope: "issue ABC-1", synced: 1 }),
+    );
+    modal.onOpen();
+    const meta = modal.contentEl.querySelector("p.jb-sync-summary-meta");
+    expect(meta?.textContent).toContain("Scope: issue ABC-1");
+    expect(meta?.textContent).toContain("Synced: 1");
+  });
+
+  it("closes when the Close button is clicked", () => {
+    const modal = new SyncFailuresModal({} as any, summary());
+    const closeSpy = vi.spyOn(modal, "close");
+    modal.onOpen();
+    buttonByText(modal, "Close").click();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("clears its content on close", () => {
+    const modal = new SyncFailuresModal({} as any, summary());
+    modal.onOpen();
+    expect(modal.contentEl.children.length).toBeGreaterThan(0);
+    modal.onClose();
+    expect(modal.contentEl.children.length).toBe(0);
+  });
+});

--- a/src/sync-failures-modal.ts
+++ b/src/sync-failures-modal.ts
@@ -1,0 +1,67 @@
+import { App, Modal, Setting } from "obsidian";
+
+export interface SyncFailure {
+  key: string;
+  kind: string;
+  message: string;
+}
+
+export interface SyncSummary {
+  scope: string;
+  synced: number;
+  failures: SyncFailure[];
+  timestamp: number;
+}
+
+function formatTimestamp(ms: number): string {
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return new Date(ms).toISOString();
+  }
+}
+
+export class SyncFailuresModal extends Modal {
+  constructor(app: App, private readonly summary: SyncSummary) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl, titleEl } = this;
+    const { scope, synced, failures, timestamp } = this.summary;
+
+    titleEl.setText(
+      failures.length === 0
+        ? "JIRA sync — last run"
+        : `JIRA sync — ${failures.length} failure${failures.length === 1 ? "" : "s"}`,
+    );
+
+    const meta = contentEl.createEl("p", { cls: "jb-sync-summary-meta" });
+    meta.setText(
+      `Scope: ${scope} · Synced: ${synced} · At: ${formatTimestamp(timestamp)}`,
+    );
+
+    if (failures.length === 0) {
+      contentEl.createEl("p", { text: "No failures in the last sync." });
+    } else {
+      const list = contentEl.createEl("ul", { cls: "jb-sync-failures-list" });
+      for (const f of failures) {
+        const li = list.createEl("li");
+        li.createEl("strong", { text: f.key });
+        li.createEl("span", { text: ` [${f.kind}] ` });
+        li.createEl("span", { text: f.message });
+      }
+    }
+
+    new Setting(contentEl).addButton((b) =>
+      b
+        .setButtonText("Close")
+        .setCta()
+        .onClick(() => this.close()),
+    );
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/sync-failures-modal.ts
+++ b/src/sync-failures-modal.ts
@@ -1,8 +1,17 @@
 import { App, Modal, Setting } from "obsidian";
 
+export type SyncFailureKind =
+  | "no-token"
+  | "auth"
+  | "not-found"
+  | "network"
+  | "http"
+  | "parse"
+  | "write";
+
 export interface SyncFailure {
   key: string;
-  kind: string;
+  kind: SyncFailureKind;
   message: string;
 }
 

--- a/src/sync-issue-modal.ts
+++ b/src/sync-issue-modal.ts
@@ -1,0 +1,62 @@
+import { App, Modal, Notice, Setting } from "obsidian";
+import { parseKeyOrUrl } from "./jira-key";
+
+export class SyncIssueModal extends Modal {
+  private input: string;
+
+  constructor(
+    app: App,
+    prefilled: string,
+    private readonly baseUrl: string,
+    private readonly onConfirm: (key: string) => void,
+  ) {
+    super(app);
+    this.input = prefilled;
+  }
+
+  onOpen(): void {
+    const { contentEl, titleEl } = this;
+    titleEl.setText("JIRA: Sync this issue");
+
+    contentEl.createEl("p", {
+      text: "Refresh the stub note for a single JIRA issue.",
+    });
+
+    new Setting(contentEl)
+      .setName("Issue key or URL")
+      .addText((t) => {
+        t.setPlaceholder("ABC-123 or https://jira.example.com/browse/ABC-123")
+          .setValue(this.input)
+          .onChange((v) => (this.input = v));
+        t.inputEl.addEventListener("keydown", (ev) => {
+          if (ev.key === "Enter") {
+            ev.preventDefault();
+            this.submit();
+          }
+        });
+      });
+
+    new Setting(contentEl)
+      .addButton((b) => b.setButtonText("Cancel").onClick(() => this.close()))
+      .addButton((b) =>
+        b
+          .setButtonText("Sync")
+          .setCta()
+          .onClick(() => this.submit()),
+      );
+  }
+
+  private submit(): void {
+    const key = parseKeyOrUrl(this.input, this.baseUrl);
+    if (!key) {
+      new Notice(`Couldn't parse '${this.input}' as a JIRA key or URL.`);
+      return;
+    }
+    this.close();
+    this.onConfirm(key);
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}


### PR DESCRIPTION
## Summary

Closes JB-11. Replaces the single-failure-only sync Notice with an inspectable failure log, adds three scoped sync commands, and makes the status-bar entry clickable.

- **Failure-log modal.** A failed sync now emits a click-through Notice that opens `SyncFailuresModal`, listing every `(key, kind, message)` triple plus the synced count and timestamp. The modal also opens via the clickable status bar and the new `JIRA: Show last sync summary` palette command.
- **Scoped sync commands.** `JIRA: Sync this note's references` (active-file scan), `JIRA: Sync this folder's references` (recursive walk of the active note's folder), and `JIRA: Sync this issue` (cursor-aware single-key prompt with `/browse/` URL support). All three delegate to the same `syncKeys(keys, scopeLabel)` core that `JIRA: Sync issue stubs` was refactored onto, so failure tracking and stub-write semantics are identical across surfaces.
- **Indexer.** `collectKeysInPaths(deps, paths, stubsFolder)` is the new exported helper that powers scoped commands; `collectAllKeys` delegates to it for the vault-wide case.
- **Mock.** The shared `__mocks__/obsidian.ts` `Modal` mock had to grow `setText` / `cls` / chained-`createEl` augmentation so any `createEl`-returned element behaves like Obsidian's patched `HTMLElement.prototype`. Existing modal tests continue to pass — the augmentation is additive.
- **Version.** 0.7.0 → 0.8.0 (additive features). CHANGELOG entry included.

No new settings, no schema or frontmatter changes, no new dependencies.

## Test plan

- [x] `npm test` — 275 / 275 (10 new: 4 `collectKeysInPaths`, 6 `SyncFailuresModal`).
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — production esbuild succeeds.
- [ ] In a live vault: trigger `JIRA: Sync issue stubs` against an issue list with at least one bad key; click the resulting Notice and confirm the modal lists every failure.
- [ ] Click the status-bar entry; confirm the same modal opens for the last sync, or a "no sync run yet" Notice when nothing has run.
- [ ] Run `JIRA: Sync this note's references` from a note that links one issue; confirm only that key is fetched.
- [ ] Run `JIRA: Sync this folder's references` from a note inside a folder; confirm recursive walk and that stubs-folder paths are excluded.
- [ ] Run `JIRA: Sync this issue` with the cursor on a bare key; confirm the modal prefills, accepts both keys and `/browse/` URLs, and rejects junk with a Notice.