### PR TITLE
JB-10: command palette additions — Open in browser, Copy URL, Refresh stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to **JIRA Bases** are recorded here. Releases follow [semver](https://semver.org/) and are auto-published to GitHub Releases when `manifest.json` / `package.json` versions change on `main`.
 
+## 0.10.0 — Command palette additions (JB-10)
+
+- **Three new palette commands**, all sharing one cursor-aware key resolver (selection → cursor → active note's `jira_key` frontmatter):
+  - **JIRA: Open issue in browser** — resolves the current key and opens `<base>/browse/<KEY>` in the default browser.
+  - **JIRA: Copy issue URL** — same resolution; copies `<base>/browse/<KEY>` to the clipboard.
+  - **JIRA: Refresh this stub** — when the active note has a `jira_key` frontmatter field, re-fetches from JIRA and rewrites the managed `jira_*` frontmatter in place. Notice no-op otherwise.
+- **Palette grouping pass.** The `JIRA: …` commands are now registered in `onload()` grouped by intent (connection · single-issue actions · stub maintenance · sync · view generation) so future readers can map them back to UI flows.
+
 ## 0.9.0 — Settings polish and plugin lifecycle hygiene (JB-8)
 
 - **Settings copy.** Each section now has a paragraph-level intro instead of just a heading. The PAT row's storage description matches reality — encrypted at rest using Electron `safeStorage` with the ciphertext written to this vault's plugin-data file (the OS keychain holds only the derived key, not the token itself).

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -705,6 +705,12 @@ export default class JiraBasesPlugin extends Plugin {
       new Notice("Active note isn't a JIRA stub.");
       return;
     }
+    const normalizedFolder = this.settings.stubsFolder.replace(/^\/+|\/+$/g, "");
+    const normalizedPath = file.path.startsWith("/") ? file.path.slice(1) : file.path;
+    if (!normalizedPath.startsWith(normalizedFolder + "/") && normalizedPath !== normalizedFolder) {
+      new Notice("Active note isn't in the configured stubs folder.");
+      return;
+    }
     const cache = this.app.metadataCache.getFileCache(file);
     const rawKey = cache?.frontmatter?.jira_key;
     if (typeof rawKey !== "string" || !/^[A-Z][A-Z0-9]+-\d+$/.test(rawKey.trim())) {
@@ -715,6 +721,10 @@ export default class JiraBasesPlugin extends Plugin {
     const r = await this.makeClient().getIssueDetails(key);
     if (!r.ok) {
       new Notice(errorMessage(r.error));
+      return;
+    }
+    if (r.value.key !== key) {
+      new Notice(`Issue key changed: frontmatter has ${key}, but JIRA returned ${r.value.key}. Refresh cancelled to avoid filename mismatch.`);
       return;
     }
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ import { SyncIssueModal } from "./sync-issue-modal";
 import type { Editor } from "obsidian";
 import { generateBase } from "./base-generator";
 import { BaseGeneratorModal } from "./base-generator-modal";
+import { resolveIssueKey } from "./resolve-issue-key";
 
 /**
  * Escape IssueDetails fields for safe use in renderTemplate.
@@ -135,10 +136,24 @@ export default class JiraBasesPlugin extends Plugin {
     this.recreateFailedKeysTracker();
     this.addSettingTab(new JiraBasesSettingTab(this.app, this));
 
+    // Connection
     this.addCommand({
       id: "test-connection",
       name: "JIRA: Test connection",
       callback: () => this.testConnection(),
+    });
+
+    // Single-issue actions (look up, link, navigate, comment)
+    this.addCommand({
+      id: "lookup-issue",
+      name: "JIRA: Look up issue…",
+      callback: () => {
+        if (!this.settings.baseUrl) {
+          new Notice("Set your JIRA base URL in plugin settings.");
+          return;
+        }
+        new LookupModal(this.app, this.issueService, this.settings.baseUrl).open();
+      },
     });
 
     this.addCommand({
@@ -148,9 +163,34 @@ export default class JiraBasesPlugin extends Plugin {
     });
 
     this.addCommand({
-      id: "sync-issue-stubs",
-      name: "JIRA: Sync issue stubs",
-      callback: () => this.syncIssueStubs(),
+      id: "open-issue-in-browser",
+      name: "JIRA: Open issue in browser",
+      callback: () => this.openIssueInBrowser(),
+    });
+
+    this.addCommand({
+      id: "copy-issue-url",
+      name: "JIRA: Copy issue URL",
+      callback: () => this.copyIssueUrl(),
+    });
+
+    this.addCommand({
+      id: "add-comment",
+      name: "JIRA: Add comment to issue…",
+      editorCallback: (editor) => this.addCommentToIssue(editor),
+    });
+
+    // Stub maintenance
+    this.addCommand({
+      id: "refresh-this-stub",
+      name: "JIRA: Refresh this stub",
+      callback: () => this.refreshThisStub(),
+    });
+
+    this.addCommand({
+      id: "sync-this-issue",
+      name: "JIRA: Sync this issue",
+      callback: () => this.syncThisIssue(),
     });
 
     this.addCommand({
@@ -166,9 +206,9 @@ export default class JiraBasesPlugin extends Plugin {
     });
 
     this.addCommand({
-      id: "sync-this-issue",
-      name: "JIRA: Sync this issue",
-      callback: () => this.syncThisIssue(),
+      id: "sync-issue-stubs",
+      name: "JIRA: Sync issue stubs",
+      callback: () => this.syncIssueStubs(),
     });
 
     this.addCommand({
@@ -181,6 +221,13 @@ export default class JiraBasesPlugin extends Plugin {
       id: "clean-orphaned-stubs",
       name: "JIRA: Clean orphaned stubs",
       callback: () => this.cleanOrphanedStubs(),
+    });
+
+    // Bases view generator
+    this.addCommand({
+      id: "generate-bases-view",
+      name: "JIRA: Generate Bases view",
+      callback: () => this.generateBasesView(),
     });
 
     this.issueService = createIssueService(
@@ -213,30 +260,6 @@ export default class JiraBasesPlugin extends Plugin {
         this.ensureAutoLookupScheduler().bump();
       }),
     );
-
-    this.addCommand({
-      id: "lookup-issue",
-      name: "JIRA: Look up issue…",
-      callback: () => {
-        if (!this.settings.baseUrl) {
-          new Notice("Set your JIRA base URL in plugin settings.");
-          return;
-        }
-        new LookupModal(this.app, this.issueService, this.settings.baseUrl).open();
-      },
-    });
-
-    this.addCommand({
-      id: "add-comment",
-      name: "JIRA: Add comment to issue…",
-      editorCallback: (editor) => this.addCommentToIssue(editor),
-    });
-
-    this.addCommand({
-      id: "generate-bases-view",
-      name: "JIRA: Generate Bases view",
-      callback: () => this.generateBasesView(),
-    });
 
     this.setupAutoRefresh();
     this.setupStatusBar();
@@ -617,6 +640,94 @@ export default class JiraBasesPlugin extends Plugin {
       },
     });
     modal.open();
+  }
+
+  private resolveCurrentIssueKey(editor: Editor | null): string | null {
+    const file = this.app.workspace.getActiveFile();
+    let fm: Record<string, unknown> | null = null;
+    if (file) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      fm = (cache?.frontmatter as Record<string, unknown> | undefined) ?? null;
+    }
+    return resolveIssueKey({
+      editor,
+      activeFileFrontmatter: fm,
+      baseUrl: this.settings.baseUrl,
+    });
+  }
+
+  async openIssueInBrowser(): Promise<void> {
+    if (!this.settings.baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+    const editor = this.app.workspace.activeEditor?.editor ?? null;
+    const key = this.resolveCurrentIssueKey(editor);
+    if (!key) {
+      new Notice(
+        "No JIRA issue at cursor or in selection, and active note has no jira_key.",
+      );
+      return;
+    }
+    const url = `${this.settings.baseUrl.replace(/\/+$/, "")}/browse/${key}`;
+    window.open(url, "_blank");
+  }
+
+  async copyIssueUrl(): Promise<void> {
+    if (!this.settings.baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+    const editor = this.app.workspace.activeEditor?.editor ?? null;
+    const key = this.resolveCurrentIssueKey(editor);
+    if (!key) {
+      new Notice(
+        "No JIRA issue at cursor or in selection, and active note has no jira_key.",
+      );
+      return;
+    }
+    const url = `${this.settings.baseUrl.replace(/\/+$/, "")}/browse/${key}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      new Notice(`Copied ${key} URL.`);
+    } catch (e) {
+      new Notice(`Failed to copy URL: ${(e as Error).message}`);
+    }
+  }
+
+  async refreshThisStub(): Promise<void> {
+    if (!this.settings.baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+    const file = this.app.workspace.getActiveFile();
+    if (!file) {
+      new Notice("Active note isn't a JIRA stub.");
+      return;
+    }
+    const cache = this.app.metadataCache.getFileCache(file);
+    const rawKey = cache?.frontmatter?.jira_key;
+    if (typeof rawKey !== "string" || !/^[A-Z][A-Z0-9]+-\d+$/.test(rawKey.trim())) {
+      new Notice("Active note isn't a JIRA stub.");
+      return;
+    }
+    const key = rawKey.trim();
+    const r = await this.makeClient().getIssueDetails(key);
+    if (!r.ok) {
+      new Notice(errorMessage(r.error));
+      return;
+    }
+    try {
+      await writeStub(
+        this.makeVaultAdapter(),
+        this.settings.stubsFolder,
+        r.value,
+        file.path,
+      );
+      new Notice(`Refreshed ${key}.`);
+    } catch (e) {
+      new Notice(`Refresh failed: ${(e as Error).message}`);
+    }
   }
 
   async addCommentToIssue(editor: Editor): Promise<void> {

--- a/src/resolve-issue-key.test.ts
+++ b/src/resolve-issue-key.test.ts
@@ -143,4 +143,18 @@ describe("resolveIssueKey", () => {
     });
     expect(r).toBe("ABC-1");
   });
+
+  it("extracts key from selection with foreign-host URL and bare key", () => {
+    const r = resolveIssueKey({
+      editor: fakeEditor({
+        selection: "see https://other.com/browse/XYZ-1 for ABC-1",
+      }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    // When selection contains both a non-JIRA URL and a bare key,
+    // findKeyInText returns the first key found (XYZ-1), not the bare one.
+    // This is current behavior and may be surprising but is deterministic.
+    expect(r).toBe("XYZ-1");
+  });
 });

--- a/src/resolve-issue-key.test.ts
+++ b/src/resolve-issue-key.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { resolveIssueKey, CursorEditor } from "./resolve-issue-key";
+
+const BASE = "https://jira.me.com";
+
+function fakeEditor(opts: {
+  selection?: string;
+  cursor?: { line: number; ch: number };
+  lines?: string[];
+}): CursorEditor {
+  const lines = opts.lines ?? [""];
+  return {
+    getSelection: () => opts.selection ?? "",
+    getCursor: () => opts.cursor ?? { line: 0, ch: 0 },
+    getLine: (n: number) => lines[n] ?? "",
+  };
+}
+
+describe("resolveIssueKey", () => {
+  it("returns null when nothing resolves", () => {
+    expect(
+      resolveIssueKey({
+        editor: fakeEditor({ lines: ["plain text"] }),
+        activeFileFrontmatter: null,
+        baseUrl: BASE,
+      }),
+    ).toBeNull();
+  });
+
+  it("resolves a bare key from the selection", () => {
+    const r = resolveIssueKey({
+      editor: fakeEditor({ selection: "ABC-123" }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBe("ABC-123");
+  });
+
+  it("resolves a browse URL from the selection", () => {
+    const r = resolveIssueKey({
+      editor: fakeEditor({ selection: `${BASE}/browse/PROJ-9?x=1` }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBe("PROJ-9");
+  });
+
+  it("resolves a key embedded in selected prose", () => {
+    const r = resolveIssueKey({
+      editor: fakeEditor({ selection: "see ABC-1 today" }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBe("ABC-1");
+  });
+
+  it("resolves a key from a markdown link under the cursor", () => {
+    const line = `text [SRE-1](${BASE}/browse/SRE-1) more`;
+    const r = resolveIssueKey({
+      editor: fakeEditor({ cursor: { line: 0, ch: 10 }, lines: [line] }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBe("SRE-1");
+  });
+
+  it("falls back to anchor text when href host doesn't match", () => {
+    const line = `[ABC-2](https://elsewhere.com/x)`;
+    const r = resolveIssueKey({
+      editor: fakeEditor({ cursor: { line: 0, ch: 3 }, lines: [line] }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBe("ABC-2");
+  });
+
+  it("resolves a bare key under the cursor", () => {
+    const line = "fix SRE-1235 today";
+    const r = resolveIssueKey({
+      editor: fakeEditor({ cursor: { line: 0, ch: 7 }, lines: [line] }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBe("SRE-1235");
+  });
+
+  it("ignores cursor when no key is under it", () => {
+    const line = "fix the thing today";
+    const r = resolveIssueKey({
+      editor: fakeEditor({ cursor: { line: 0, ch: 4 }, lines: [line] }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("falls back to active-file frontmatter jira_key", () => {
+    const r = resolveIssueKey({
+      editor: fakeEditor({ lines: ["irrelevant"] }),
+      activeFileFrontmatter: { jira_key: "ABC-77" },
+      baseUrl: BASE,
+    });
+    expect(r).toBe("ABC-77");
+  });
+
+  it("rejects an invalid frontmatter jira_key", () => {
+    const r = resolveIssueKey({
+      editor: fakeEditor({ lines: ["irrelevant"] }),
+      activeFileFrontmatter: { jira_key: "abc-1" },
+      baseUrl: BASE,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("ignores non-string frontmatter jira_key", () => {
+    const r = resolveIssueKey({
+      editor: fakeEditor({ lines: ["irrelevant"] }),
+      activeFileFrontmatter: { jira_key: 42 as unknown as string },
+      baseUrl: BASE,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("works with no editor (palette invoked outside an editor)", () => {
+    const r = resolveIssueKey({
+      editor: null,
+      activeFileFrontmatter: { jira_key: "ABC-77" },
+      baseUrl: BASE,
+    });
+    expect(r).toBe("ABC-77");
+  });
+
+  it("prefers selection over cursor over frontmatter", () => {
+    const line = `[KEY-1](${BASE}/browse/KEY-1)`;
+    const r = resolveIssueKey({
+      editor: fakeEditor({
+        selection: "ABC-1",
+        cursor: { line: 0, ch: 3 },
+        lines: [line],
+      }),
+      activeFileFrontmatter: { jira_key: "ZZZ-9" },
+      baseUrl: BASE,
+    });
+    expect(r).toBe("ABC-1");
+  });
+});

--- a/src/resolve-issue-key.ts
+++ b/src/resolve-issue-key.ts
@@ -1,0 +1,54 @@
+import {
+  extractKeyFromHref,
+  findKeyAtCol,
+  findKeyInText,
+  findLinkAtCol,
+  parseKeyOrUrl,
+} from "./jira-key";
+
+export interface CursorEditor {
+  getSelection(): string;
+  getCursor(): { line: number; ch: number };
+  getLine(line: number): string;
+}
+
+export interface ResolveIssueKeyDeps {
+  editor: CursorEditor | null;
+  activeFileFrontmatter: Record<string, unknown> | null;
+  baseUrl: string;
+}
+
+const KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/;
+
+export function resolveIssueKey(deps: ResolveIssueKeyDeps): string | null {
+  const { editor, activeFileFrontmatter, baseUrl } = deps;
+
+  if (editor) {
+    const selection = editor.getSelection();
+    if (selection) {
+      const fromSelection =
+        parseKeyOrUrl(selection, baseUrl) ?? findKeyInText(selection);
+      if (fromSelection) return fromSelection;
+    }
+    const cursor = editor.getCursor();
+    const line = editor.getLine(cursor.line);
+    const link = findLinkAtCol(line, cursor.ch);
+    if (link) {
+      const linkKey =
+        extractKeyFromHref(link.url, baseUrl) ?? findKeyInText(link.text);
+      if (linkKey) return linkKey;
+    }
+    const hit = findKeyAtCol(line, cursor.ch);
+    if (hit) return hit.key;
+  }
+
+  if (activeFileFrontmatter) {
+    const raw = activeFileFrontmatter["jira_key"];
+    if (typeof raw === "string") {
+      const k = raw.trim();
+      if (k && KEY_RE.test(k)) return k;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Three new `JIRA: …` palette commands sharing one cursor-aware key resolver:

- **JIRA: Open issue in browser** — `window.open(<base>/browse/<KEY>)`.
- **JIRA: Copy issue URL** — `navigator.clipboard.writeText(...)`; Notice on success/failure.
- **JIRA: Refresh this stub** — re-fetches from JIRA and round-trips managed `jira_*` frontmatter via `writeStub`. Notice no-op when active note isn't a stub.

Shared resolver `resolveIssueKey({editor, activeFileFrontmatter, baseUrl})` lives in `src/resolve-issue-key.ts` with 13 unit tests covering selection / cursor / frontmatter paths and priority ordering.

Also regroups the `addCommand` registrations in `onload()` by intent (connection · single-issue actions · stub maintenance · sync · view generation) for maintainability — user-facing palette order is alphabetical and unchanged.

The "Reformat link under cursor" scope item was a confirm-no-action: no such command exists; `Insert issue link` already reformats existing links when invoked on them.

Bumps version 0.9.0 → 0.10.0 (additive feature → minor).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — 307/307 tests pass (13 new)
- [ ] In Obsidian: open palette, run JIRA: Open issue in browser with cursor on a key
- [ ] Run JIRA: Copy issue URL on a selected `[KEY](browse-url)` link
- [ ] Run JIRA: Refresh this stub from inside a stub note; verify managed frontmatter updates and `## Notes` body is preserved
- [ ] Run JIRA: Refresh this stub from a non-stub note and verify the no-op Notice