### PR TITLE
JB-13: 1.0.0 release — version bump and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to **JIRA Bases** are recorded here. Releases follow [semver](https://semver.org/) and are auto-published to GitHub Releases when `manifest.json` / `package.json` versions change on `main`.
 
+## 1.0.0 — Stable release (JB-13)
+
+Promotes the plugin out of the 0.x pre-stable line. No new behavior vs 0.10.0 — the major bump signals a stability commitment for the public surface (commands, settings, stub frontmatter, link templates, `.base` generator, hover preview, sync). The polish arc that landed across 0.6.3 → 0.10.0 is now considered the 1.0 baseline:
+
+- **0.6.3 / 0.7.0** — install path docs (BRAT, JB-9), Generate Bases overwrite confirm (JB-14).
+- **0.8.0** — sync UX: failure-log modal, scoped sync (note / folder / single issue), clickable status bar (JB-11).
+- **0.9.0** — settings polish (paragraph intros, ms→seconds, inline validation, inline Test connection) and plugin lifecycle hygiene via `onunload()` (JB-8).
+- **0.10.0** — three new palette commands: open in browser, copy URL, refresh stub (JB-10).
+
+See the per-version blocks below for the detail in each release. No breaking changes vs 0.10.0; existing settings, frontmatter shape, and command IDs are preserved.
+
 ## 0.10.0 — Command palette additions (JB-10)
 
 - **Three new palette commands**, all sharing one cursor-aware key resolver (selection → cursor → active note's `jira_key` frontmatter):
@@ -28,6 +39,14 @@ All notable changes to **JIRA Bases** are recorded here. Releases follow [semver
   - **JIRA: Sync this folder's references** — scans every `.md` under the active note's folder (recursive).
   - **JIRA: Sync this issue** — single-key prompt; auto-fills from the cursor when a JIRA key is under it.
 - **Clickable status bar.** The "JIRA: Last synced …" status-bar item is now interactive — click to reopen the last sync's failure log. Same surface is also available as the **JIRA: Show last sync summary** command for keyboard-only users.
+
+## 0.7.0 — Generate Bases overwrite confirm (JB-14)
+
+- **JIRA: Generate Bases view** now prompts for confirmation before overwriting an existing `JIRA Issues.base` in the stubs folder, instead of silently replacing it. Choosing *Cancel* leaves the existing file untouched.
+
+## 0.6.3 — BRAT install path in README (JB-9)
+
+- README's Quick Start now leads with the BRAT install path (recommended), with the from-source path retained for plugin developers. No code change.
 
 ## 0.6.2 — README rewrite (JB-7)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "0.8.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps `manifest.json` + `package.json` (and the lockfile) from **0.10.0 → 1.0.0**, promoting the plugin out of the 0.x pre-stable line.
- No code changes. The major bump signals stability commitment for the public surface (commands, settings, stub frontmatter, link templates, `.base` generator, hover preview, sync) — the polish arc that shipped across 0.6.3 → 0.10.0 is now the 1.0 baseline.
- Adds a `## 1.0.0 — Stable release` block to `CHANGELOG.md` and back-fills the previously-undocumented `0.6.3` (JB-9 BRAT install path) and `0.7.0` (JB-14 Generate Bases overwrite confirm) entries so the file matches the actual release-tag history.

## Strategy

Strategy A from JB-6 (0.9.x progression then 1.0.0 cut at JB-13). No SemVer break vs 0.10.0 — existing settings, frontmatter shape, command IDs preserved.

## Test plan

- [x] `npm run build` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 308/308 pass
- [ ] After merge: `gh release list --limit 5` shows `1.0.0` tag within ~2 minutes (release CI auto-publishes on `manifest.json` version change).
- [ ] User smoke test on a fresh vault via BRAT — install, configure baseUrl + PAT, run insert link / sync / hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)