### PR TITLE
JB-18: add local-first issue search

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ An Obsidian plugin that turns your JIRA issues into first-class Bases data — s
 
 JIRA Bases keeps a folder of read-only **stub notes** in your vault — one note per JIRA issue you reference — with managed frontmatter (`jira_status`, `jira_priority`, `jira_assignee`, …). Pair it with [Obsidian Bases](https://help.obsidian.md/bases) and you get a sortable, filterable table of your JIRA issues that lives entirely in your vault. The plugin also inserts smart links, previews issues on hover, and (optionally) replaces bare issue keys you type with proper links.
 
-Four flows you'll use most:
+Five flows you'll use most:
 
 1. **Insert a JIRA link** — fuzzy-pick an issue, paste a configurable link template.
-2. **Sync stubs and view them in Bases** — scans your vault for JIRA references, fetches fields, writes one stub per issue, then renders them through a generated `.base` view.
-3. **Hover or look up an issue** — preview summary, status, type, priority, assignee, reporter, and last-updated time without leaving the editor.
-4. **Auto-lookup as you type (passive)** — type bare keys like `ABC-123` in any note and the plugin replaces them with proper links after a brief idle pause. The fully passive companion to flow #1 — no palette, no selection, no thought required. See [Auto-lookup on type](#auto-lookup-on-type).
+2. **Search issues from the palette** — get instant local stub matches, then press Cmd-Enter or click **Search on server** for live JIRA results. Enter inserts the selected issue; Cmd-Enter opens it in your browser.
+3. **Sync stubs and view them in Bases** — scans your vault for JIRA references, fetches fields, writes one stub per issue, then renders them through a generated `.base` view.
+4. **Hover or look up an issue** — preview summary, status, type, priority, assignee, reporter, and last-updated time without leaving the editor.
+5. **Auto-lookup as you type (passive)** — type bare keys like `ABC-123` in any note and the plugin replaces them with proper links after a brief idle pause. The fully passive companion to flow #1 — no palette, no selection, no thought required. See [Auto-lookup on type](#auto-lookup-on-type).
 
 <!-- TODO: capture docs/screenshots/insert-link.gif — Insert issue link flow -->
 <!-- TODO: capture docs/screenshots/sync-and-base.gif — Sync stubs + Bases view -->
@@ -66,7 +67,11 @@ Open the command palette and run **JIRA: Insert issue link**. Type any part of t
 
 To wrap an existing selection, select the text first, then run **JIRA: Insert issue link** — the suggestion modal will use your selection as the seed search.
 
-### 3a. Enable auto-lookup as you type (optional, passive)
+### 3a. Search issues from the palette
+
+Open the command palette and run **JIRA: Search issues…**. As you type, the modal searches your local stub notes immediately. Press **Cmd-Enter** or click **Search on server** to replace those local matches with live JIRA results; JQL is passed through when detected. Press **Enter** on a selected result to insert it with your standard link template, or **Cmd-Enter** on a selected result to open it in the browser.
+
+### 3b. Enable auto-lookup as you type (optional, passive)
 
 If you write notes that mention JIRA issues by key (`ABC-123` in a meeting note, a daily log, a roadmap doc), turn on **Auto-lookup on type** and skip the palette entirely.
 
@@ -98,6 +103,7 @@ For one-off lookups without inserting a link, run **JIRA: Look up issue…** and
 | :--- | :--- |
 | **JIRA: Test connection** | Calls `/rest/api/2/myself`. Returns the authenticated user. |
 | **JIRA: Insert issue link** | Fuzzy-pick an issue and insert a markdown link using your *Link template*. Works on the current selection too. |
+| **JIRA: Search issues…** | Search local stub notes instantly, then press Cmd-Enter or click **Search on server** for live JIRA results. Enter inserts the selected issue; Cmd-Enter opens it in the browser. |
 | **JIRA: Sync issue stubs** | Scans the vault for JIRA references, fetches fields, writes/updates stubs in your *Stubs folder*. |
 | **JIRA: Clean orphaned stubs** | Deletes stub notes whose issue is no longer referenced anywhere in the vault. |
 | **JIRA: Look up issue…** | Modal that accepts a key or browse URL and renders the same preview as hover. |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "1.0.0",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {

--- a/src/issue-suggest-helpers.ts
+++ b/src/issue-suggest-helpers.ts
@@ -1,7 +1,1 @@
-export function isIssueKey(input: string): boolean {
-  return /^[A-Za-z][A-Za-z0-9]+-\d+$/.test(input);
-}
-
-export function escapeJqlText(input: string): string {
-  return input.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
+export { escapeJqlText, isIssueKey } from "./search-helpers";

--- a/src/jira-client.ts
+++ b/src/jira-client.ts
@@ -1,4 +1,4 @@
-import { escapeJqlText } from "./issue-suggest-helpers";
+import { buildSearchJql } from "./search-helpers";
 import { parseIssueDetails, IssueDetails } from "./jira-fields";
 
 export type CurrentUser = {
@@ -225,7 +225,7 @@ export function createJiraClient(opts: JiraClientOptions): JiraClient {
       const token = await opts.getToken();
       if (!token) return { ok: false, error: { kind: "no-token" } };
 
-      const jql = `text ~ "${escapeJqlText(query)}" ORDER BY updated DESC`;
+      const jql = buildSearchJql(query);
       const url =
         `${base}/rest/api/2/search` +
         `?jql=${encodeURIComponent(jql)}` +

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,8 @@ import type { Editor } from "obsidian";
 import { generateBase } from "./base-generator";
 import { BaseGeneratorModal } from "./base-generator-modal";
 import { resolveIssueKey } from "./resolve-issue-key";
+import { SearchModal } from "./search-modal";
+import type { SearchIssue } from "./search-helpers";
 
 /**
  * Escape IssueDetails fields for safe use in renderTemplate.
@@ -162,6 +164,12 @@ export default class JiraBasesPlugin extends Plugin {
       id: "insert-issue-link",
       name: "JIRA: Insert issue link",
       editorCallback: (editor) => this.insertIssueLink(editor),
+    });
+
+    this.addCommand({
+      id: "search-issues",
+      name: "JIRA: Search issues…",
+      callback: () => this.searchIssuesCommand(),
     });
 
     this.addCommand({
@@ -644,6 +652,81 @@ export default class JiraBasesPlugin extends Plugin {
     modal.open();
   }
 
+  private collectStubIssues(): SearchIssue[] {
+    const folder = this.settings.stubsFolder.replace(/^\/+|\/+$/g, "");
+    const prefix = folder ? `${folder}/` : "";
+    const issues = new Map<string, SearchIssue>();
+
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      if (prefix && !file.path.startsWith(prefix)) continue;
+      const frontmatter =
+        (this.app.metadataCache.getFileCache(file)?.frontmatter as
+          | Record<string, unknown>
+          | undefined) ?? null;
+      if (!frontmatter) continue;
+      const key = frontmatter.jira_key;
+      const summary = frontmatter.jira_summary;
+      if (typeof key !== "string" || typeof summary !== "string") continue;
+      const rawLabels = frontmatter.jira_labels;
+      const labels = Array.isArray(rawLabels)
+        ? rawLabels.filter((value: unknown): value is string => typeof value === "string")
+        : [];
+      issues.set(key, {
+        key,
+        summary,
+        status: typeof frontmatter.jira_status === "string" ? frontmatter.jira_status : "",
+        type: typeof frontmatter.jira_type === "string" ? frontmatter.jira_type : "",
+        priority:
+          typeof frontmatter.jira_priority === "string" ? frontmatter.jira_priority : null,
+        assignee:
+          typeof frontmatter.jira_assignee === "string" ? frontmatter.jira_assignee : null,
+        reporter:
+          typeof frontmatter.jira_reporter === "string" ? frontmatter.jira_reporter : null,
+        labels,
+        updated: typeof frontmatter.jira_updated === "string" ? frontmatter.jira_updated : "",
+      });
+    }
+
+    return [...issues.values()];
+  }
+
+  private async insertIssueByKey(key: string): Promise<void> {
+    const editor = this.app.workspace.activeEditor?.editor;
+    if (!editor) {
+      new Notice("Open a note with an editor to insert a JIRA link.");
+      return;
+    }
+    const result = await this.makeClient().getIssueDetails(key);
+    if (!result.ok) {
+      new Notice(errorMessage(result.error));
+      return;
+    }
+    editor.replaceSelection(
+      renderTemplate(this.settings.linkTemplate, escapeIssueDetailsForTemplate(result.value)),
+    );
+  }
+
+  private openIssueKeyInBrowser(key: string): void {
+    const url = `${this.settings.baseUrl.replace(/\/+$/, "")}/browse/${key}`;
+    window.open(url, "_blank");
+  }
+
+  async searchIssuesCommand(): Promise<void> {
+    if (!this.settings.baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+
+    const modal = new SearchModal({
+      app: this.app,
+      client: this.makeClient(),
+      loadLocalIssues: () => this.collectStubIssues(),
+      onInsert: (issue) => this.insertIssueByKey(issue.key),
+      onOpenIssue: (issue) => this.openIssueKeyInBrowser(issue.key),
+    });
+    modal.open();
+  }
+
   private resolveCurrentIssueKey(editor: Editor | null): string | null {
     const file = this.app.workspace.getActiveFile();
     let fm: Record<string, unknown> | null = null;
@@ -671,8 +754,7 @@ export default class JiraBasesPlugin extends Plugin {
       );
       return;
     }
-    const url = `${this.settings.baseUrl.replace(/\/+$/, "")}/browse/${key}`;
-    window.open(url, "_blank");
+    this.openIssueKeyInBrowser(key);
   }
 
   async copyIssueUrl(): Promise<void> {

--- a/src/search-helpers.test.ts
+++ b/src/search-helpers.test.ts
@@ -90,10 +90,16 @@ describe("searchLocalIssues", () => {
     expect(searchLocalIssues(ISSUES, "Eugene", 20).map((issue) => issue.key)).toEqual([
       "ABC-123",
     ]);
+    expect(searchLocalIssues(ISSUES, "Colleague", 20).map((issue) => issue.key)).toEqual([
+      "ABC-123",
+    ]);
     expect(searchLocalIssues(ISSUES, "frontend", 20).map((issue) => issue.key)).toEqual([
       "ABC-123",
     ]);
     expect(searchLocalIssues(ISSUES, "High", 20).map((issue) => issue.key)).toEqual([
+      "ABC-123",
+    ]);
+    expect(searchLocalIssues(ISSUES, "2026-05-01", 20).map((issue) => issue.key)).toEqual([
       "ABC-123",
     ]);
   });

--- a/src/search-helpers.test.ts
+++ b/src/search-helpers.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeSearchQuery,
+  buildSearchJql,
+  extractLocalSearchTerms,
+  getInputKeyAction,
+  getResultKeyAction,
+  looksLikeJql,
+  searchLocalIssues,
+  type SearchIssue,
+} from "./search-helpers";
+
+const ISSUES: SearchIssue[] = [
+  {
+    key: "ABC-123",
+    summary: "Fix login bug",
+    status: "Open",
+    type: "Bug",
+    priority: "High",
+    assignee: "Eugene",
+    reporter: "Colleague",
+    labels: ["frontend", "auth"],
+    updated: "2026-05-01T10:00:00.000Z",
+  },
+  { key: "ABC-456", summary: "Improve login screen", status: "In Progress", type: "Task" },
+  { key: "OPS-1", summary: "Investigate flaky sync", status: "Open", type: "Spike" },
+];
+
+function keyEvent(
+  key: string,
+  mods: { metaKey?: boolean; ctrlKey?: boolean } = {},
+): KeyboardEvent {
+  return {
+    key,
+    metaKey: mods.metaKey ?? false,
+    ctrlKey: mods.ctrlKey ?? false,
+  } as KeyboardEvent;
+}
+
+describe("search query helpers", () => {
+  it("detects JQL-looking queries", () => {
+    expect(looksLikeJql('project = ABC AND text ~ "login"')).toBe(true);
+    expect(looksLikeJql("status in (Open, Closed)")).toBe(true);
+    expect(looksLikeJql("fix login")).toBe(false);
+  });
+
+  it("extracts local search terms from text and JQL", () => {
+    expect(extractLocalSearchTerms("fix login")).toEqual(["fix", "login"]);
+    expect(extractLocalSearchTerms('project = ABC AND text ~ "fix login"')).toEqual([
+      "abc",
+      "fix",
+      "login",
+    ]);
+  });
+
+  it("classifies empty, text, and jql queries", () => {
+    expect(analyzeSearchQuery("  ").mode).toBe("empty");
+    expect(analyzeSearchQuery("fix login").mode).toBe("text");
+    expect(analyzeSearchQuery("status = Open").mode).toBe("jql");
+  });
+
+  it("builds plain-text JQL and passes JQL through", () => {
+    expect(buildSearchJql('he said "hi"')).toBe(
+      'text ~ "he said \\"hi\\"" ORDER BY updated DESC',
+    );
+    expect(buildSearchJql("project = ABC")).toBe("project = ABC ORDER BY updated DESC");
+    expect(buildSearchJql("project = ABC ORDER BY created ASC")).toBe(
+      "project = ABC ORDER BY created ASC",
+    );
+  });
+});
+
+describe("searchLocalIssues", () => {
+  it("prefers exact key matches over summary-only matches", () => {
+    const results = searchLocalIssues(ISSUES, "ABC-123", 20);
+    expect(results.map((issue) => issue.key)).toEqual(["ABC-123"]);
+  });
+
+  it("returns fuzzy local matches ordered by relevance", () => {
+    const results = searchLocalIssues(ISSUES, "login", 20);
+    expect(results.map((issue) => issue.key)).toEqual(["ABC-123", "ABC-456"]);
+  });
+
+  it("extracts JQL terms before matching local issues", () => {
+    const results = searchLocalIssues(ISSUES, 'project = ABC AND text ~ "login"', 20);
+    expect(results.map((issue) => issue.key)).toEqual(["ABC-123", "ABC-456"]);
+  });
+
+  it("matches on sidebar/preview metadata fields too", () => {
+    expect(searchLocalIssues(ISSUES, "Eugene", 20).map((issue) => issue.key)).toEqual([
+      "ABC-123",
+    ]);
+    expect(searchLocalIssues(ISSUES, "frontend", 20).map((issue) => issue.key)).toEqual([
+      "ABC-123",
+    ]);
+    expect(searchLocalIssues(ISSUES, "High", 20).map((issue) => issue.key)).toEqual([
+      "ABC-123",
+    ]);
+  });
+});
+
+describe("keyboard actions", () => {
+  it("maps input keys to modal actions", () => {
+    expect(getInputKeyAction(keyEvent("Escape"), { hasResults: true })).toBe("close");
+    expect(getInputKeyAction(keyEvent("Enter", { metaKey: true }), { hasResults: false })).toBe(
+      "search-server",
+    );
+    expect(getInputKeyAction(keyEvent("ArrowDown"), { hasResults: true })).toBe("select-first");
+    expect(getInputKeyAction(keyEvent("ArrowUp"), { hasResults: true })).toBe("select-last");
+    expect(getInputKeyAction(keyEvent("Enter"), { hasResults: true })).toBe("insert-first");
+  });
+
+  it("maps result-list keys to navigation and actions", () => {
+    expect(getResultKeyAction(keyEvent("Escape"))).toBe("focus-input");
+    expect(getResultKeyAction(keyEvent("ArrowDown"))).toBe("move-next");
+    expect(getResultKeyAction(keyEvent("ArrowUp"))).toBe("move-prev");
+    expect(getResultKeyAction(keyEvent("Enter"))).toBe("insert");
+    expect(getResultKeyAction(keyEvent("Enter", { ctrlKey: true }))).toBe("open");
+  });
+});

--- a/src/search-helpers.ts
+++ b/src/search-helpers.ts
@@ -1,0 +1,263 @@
+import type { Issue } from "./jira-client";
+
+const ISSUE_KEY_RE = /^[A-Za-z][A-Za-z0-9]+-\d+$/;
+const JQL_FIELD_RE =
+  /\b[A-Za-z][A-Za-z0-9_.-]*\s*(?:=|!=|~|!~|>=|<=|>|<)\s*(?:"[^"]*"|'[^']*'|[A-Za-z0-9_.-]+)/i;
+const JQL_CLAUSE_RE =
+  /\b(?:ORDER\s+BY|NOT\s+IN|IN|IS(?:\s+NOT)?|WAS|CHANGED)\b/i;
+const ORDER_BY_RE = /\border\s+by\b/i;
+const JQL_KEYWORDS = new Set([
+  "and",
+  "or",
+  "not",
+  "in",
+  "is",
+  "was",
+  "changed",
+  "order",
+  "by",
+  "asc",
+  "desc",
+  "text",
+  "summary",
+  "status",
+  "project",
+  "assignee",
+  "reporter",
+  "labels",
+  "label",
+  "priority",
+  "issuetype",
+  "type",
+  "created",
+  "updated",
+  "empty",
+  "null",
+]);
+
+export interface SearchIssue extends Issue {
+  priority?: string | null;
+  assignee?: string | null;
+  reporter?: string | null;
+  labels?: string[];
+  updated?: string;
+}
+
+export interface SearchQueryPlan {
+  mode: "empty" | "text" | "jql";
+  trimmed: string;
+  localTerms: string[];
+}
+
+export type SearchInputKeyAction =
+  | "none"
+  | "close"
+  | "search-server"
+  | "select-first"
+  | "select-last"
+  | "insert-first";
+
+export type SearchResultKeyAction =
+  | "none"
+  | "focus-input"
+  | "move-prev"
+  | "move-next"
+  | "insert"
+  | "open";
+
+type KeyLikeEvent = Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey">;
+
+export function isIssueKey(input: string): boolean {
+  return ISSUE_KEY_RE.test(input);
+}
+
+export function escapeJqlText(input: string): string {
+  return input.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function looksLikeJql(input: string): boolean {
+  const trimmed = input.trim();
+  if (!trimmed) return false;
+  return JQL_FIELD_RE.test(trimmed) || JQL_CLAUSE_RE.test(trimmed);
+}
+
+function tokenize(input: string): string[] {
+  return input
+    .toLowerCase()
+    .split(/[^a-z0-9-]+/)
+    .filter(Boolean);
+}
+
+export function extractLocalSearchTerms(input: string): string[] {
+  const trimmed = input.trim();
+  if (!trimmed) return [];
+  const source = looksLikeJql(trimmed)
+    ? trimmed
+        .replace(/"([^"]*)"|'([^']*)'/g, (_match, dq: string, sq: string) => {
+          const value = dq || sq;
+          return value ? ` ${value} ` : " ";
+        })
+        .replace(/[()]/g, " ")
+    : trimmed;
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const token of tokenize(source)) {
+    if (JQL_KEYWORDS.has(token)) continue;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    out.push(token);
+  }
+  return out;
+}
+
+export function analyzeSearchQuery(input: string): SearchQueryPlan {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { mode: "empty", trimmed: "", localTerms: [] };
+  }
+  return {
+    mode: looksLikeJql(trimmed) ? "jql" : "text",
+    trimmed,
+    localTerms: extractLocalSearchTerms(trimmed),
+  };
+}
+
+export function buildSearchJql(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return "";
+  if (looksLikeJql(trimmed)) {
+    return ORDER_BY_RE.test(trimmed) ? trimmed : `${trimmed} ORDER BY updated DESC`;
+  }
+  return `text ~ "${escapeJqlText(trimmed)}" ORDER BY updated DESC`;
+}
+
+function scoreIssue(issue: SearchIssue, terms: string[], fullQuery: string): number | null {
+  const key = issue.key.toLowerCase();
+  const summary = issue.summary.toLowerCase();
+  const status = issue.status.toLowerCase();
+  const type = issue.type.toLowerCase();
+  const priority = issue.priority?.toLowerCase() ?? "";
+  const assignee = issue.assignee?.toLowerCase() ?? "";
+  const reporter = issue.reporter?.toLowerCase() ?? "";
+  const labels = (issue.labels ?? []).join(" ").toLowerCase();
+  const updated = issue.updated?.toLowerCase() ?? "";
+  const haystack = `${key} ${summary} ${status} ${type} ${priority} ${assignee} ${reporter} ${labels} ${updated}`;
+  let score = 0;
+
+  for (const term of terms) {
+    let matched = false;
+
+    if (key === term) {
+      score += 500;
+      matched = true;
+    } else if (key.startsWith(term)) {
+      score += 250;
+      matched = true;
+    } else if (key.includes(term)) {
+      score += 175;
+      matched = true;
+    }
+
+    if (summary.startsWith(term)) {
+      score += 140;
+      matched = true;
+    } else if (summary.includes(term)) {
+      score += 110;
+      matched = true;
+    }
+
+    if (status.startsWith(term) || type.startsWith(term)) {
+      score += 60;
+      matched = true;
+    } else if (status.includes(term) || type.includes(term)) {
+      score += 40;
+      matched = true;
+    }
+
+    if (priority.startsWith(term)) {
+      score += 55;
+      matched = true;
+    } else if (priority.includes(term)) {
+      score += 35;
+      matched = true;
+    }
+
+    if (assignee.startsWith(term) || reporter.startsWith(term)) {
+      score += 50;
+      matched = true;
+    } else if (assignee.includes(term) || reporter.includes(term)) {
+      score += 30;
+      matched = true;
+    }
+
+    if (labels.split(/\s+/).some((label) => label === term)) {
+      score += 55;
+      matched = true;
+    } else if (labels.includes(term)) {
+      score += 35;
+      matched = true;
+    }
+
+    if (updated.includes(term)) {
+      score += 15;
+      matched = true;
+    }
+
+    if (!matched && haystack.includes(term)) {
+      score += 10;
+      matched = true;
+    }
+
+    if (!matched) return null;
+  }
+
+  if (fullQuery && (summary.includes(fullQuery) || key.includes(fullQuery))) {
+    score += 80;
+  }
+
+  return score;
+}
+
+export function searchLocalIssues(
+  issues: SearchIssue[],
+  input: string,
+  limit: number,
+): SearchIssue[] {
+  const plan = analyzeSearchQuery(input);
+  if (plan.localTerms.length === 0) return [];
+
+  const scored = issues.flatMap((issue) => {
+    const score = scoreIssue(issue, plan.localTerms, plan.trimmed.toLowerCase());
+    return score === null ? [] : [{ issue, score }];
+  });
+
+  scored.sort((a, b) => b.score - a.score || a.issue.key.localeCompare(b.issue.key));
+  return scored.slice(0, limit).map(({ issue }) => issue);
+}
+
+function isModEnter(evt: KeyLikeEvent): boolean {
+  return evt.key === "Enter" && (evt.metaKey || evt.ctrlKey);
+}
+
+export function getInputKeyAction(
+  evt: KeyLikeEvent,
+  opts: { hasResults: boolean },
+): SearchInputKeyAction {
+  if (evt.key === "Escape") return "close";
+  if (isModEnter(evt)) return "search-server";
+  if (!opts.hasResults) return "none";
+  if (evt.key === "ArrowDown") return "select-first";
+  if (evt.key === "ArrowUp") return "select-last";
+  if (evt.key === "Enter") return "insert-first";
+  return "none";
+}
+
+export function getResultKeyAction(evt: KeyLikeEvent): SearchResultKeyAction {
+  if (evt.key === "Escape") return "focus-input";
+  if (evt.key === "ArrowDown") return "move-next";
+  if (evt.key === "ArrowUp") return "move-prev";
+  if (isModEnter(evt)) return "open";
+  if (evt.key === "Enter") return "insert";
+  return "none";
+}

--- a/src/search-modal.test.ts
+++ b/src/search-modal.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import type { Issue, JiraClient, Result } from "./jira-client";
+import { SearchModal } from "./search-modal";
+
+function issue(key: string, summary = `Summary for ${key}`): Issue {
+  return { key, summary, status: "Open", type: "Task" };
+}
+
+function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value } as Result<T, never>;
+}
+
+function createClient(overrides: Partial<JiraClient> = {}): JiraClient {
+  return {
+    getCurrentUser: vi.fn(),
+    getIssue: vi.fn(async (key: string) => ok(issue(key, `Server ${key}`))),
+    searchIssues: vi.fn(async () => ok([issue("SRV-1", "Server result")])),
+    getIssueDetails: vi.fn(),
+    addComment: vi.fn(),
+    ...overrides,
+  } as unknown as JiraClient;
+}
+
+function createModal(opts: Partial<{
+  client: JiraClient;
+  localIssues: Issue[];
+  onInsert: (issue: Issue) => void | Promise<void>;
+  onOpenIssue: (issue: Issue) => void | Promise<void>;
+}> = {}) {
+  const modal = new SearchModal({
+    app: {} as any,
+    client: opts.client ?? createClient(),
+    loadLocalIssues: () => opts.localIssues ?? [issue("LOC-1", "Local match")],
+    onInsert: opts.onInsert ?? vi.fn(),
+    onOpenIssue: opts.onOpenIssue ?? vi.fn(),
+  });
+  return modal;
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("SearchModal", () => {
+  it("renders title, helper text, and server-search button", () => {
+    const modal = createModal();
+    modal.onOpen();
+    expect(modal.titleEl.textContent).toBe("JIRA: Search issues");
+    expect(modal.contentEl.textContent).toContain(
+      "Search local stubs instantly.",
+    );
+    expect(
+      Array.from(modal.contentEl.querySelectorAll("button")).some(
+        (button) => button.textContent === "Search on server",
+      ),
+    ).toBe(true);
+  });
+
+  it("shows local results and the server hint while typing", () => {
+    const modal = createModal({
+      localIssues: [issue("LOC-1", "Fix login locally"), issue("OTHER-1", "Nothing here")],
+    });
+    modal.onOpen();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    input.value = "login";
+    input.dispatchEvent(new Event("input"));
+
+    expect(modal.contentEl.textContent).toContain("Cmd-Enter to search on server");
+    expect(modal.contentEl.textContent).toContain("LOC-1 — Fix login locally");
+    expect(modal.contentEl.textContent).not.toContain("OTHER-1 — Nothing here");
+  });
+
+  it("replaces local matches with server results when searching on server", async () => {
+    const modal = createModal({
+      localIssues: [issue("LOC-1", "Local match")],
+      client: createClient({
+        searchIssues: vi.fn(async () => ok([issue("SRV-2", "Server-only match")])),
+      }),
+    });
+    modal.onOpen();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    input.value = "server";
+    input.dispatchEvent(new Event("input"));
+
+    const button = Array.from(modal.contentEl.querySelectorAll("button")).find(
+      (el) => el.textContent === "Search on server",
+    ) as HTMLButtonElement;
+    button.click();
+    await flush();
+
+    expect(modal.contentEl.textContent).not.toContain("LOC-1 — Local match");
+    expect(modal.contentEl.textContent).toContain("SRV-2 — Server-only match");
+    expect(modal.contentEl.textContent).toContain("Showing live JIRA server results.");
+  });
+
+  it("uses Cmd-Enter in the input to trigger server search", async () => {
+    const searchIssues = vi.fn(async () => ok([issue("SRV-3", "Keyboard result")]));
+    const modal = createModal({ client: createClient({ searchIssues }) });
+    modal.onOpen();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    input.value = "server";
+    input.dispatchEvent(new Event("input"));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true }));
+    await flush();
+
+    expect(searchIssues).toHaveBeenCalledWith("server", 20);
+    expect(modal.contentEl.textContent).toContain("SRV-3 — Keyboard result");
+  });
+
+  it("inserts the first selected result on Enter from the input", async () => {
+    const onInsert = vi.fn();
+    const modal = createModal({
+      localIssues: [issue("LOC-1", "Fix login locally")],
+      onInsert,
+    });
+    const closeSpy = vi.spyOn(modal, "close");
+    modal.onOpen();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    input.value = "login";
+    input.dispatchEvent(new Event("input"));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    await flush();
+
+    expect(onInsert).toHaveBeenCalledWith(issue("LOC-1", "Fix login locally"));
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("opens the selected result in browser on Cmd-Enter from the results list", async () => {
+    const onOpenIssue = vi.fn();
+    const modal = createModal({
+      localIssues: [issue("LOC-1", "Fix login locally")],
+      onOpenIssue,
+    });
+    const closeSpy = vi.spyOn(modal, "close");
+    modal.onOpen();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    input.value = "login";
+    input.dispatchEvent(new Event("input"));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+
+    const resultButton = Array.from(modal.contentEl.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("LOC-1"),
+    ) as HTMLButtonElement;
+    resultButton.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true }));
+    await flush();
+
+    expect(onOpenIssue).toHaveBeenCalledWith(issue("LOC-1", "Fix login locally"));
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("returns focus to the input and selects the text on Escape from the results list", () => {
+    const modal = createModal({
+      localIssues: [issue("LOC-1", "Fix login locally")],
+    });
+    modal.onOpen();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    const focusSpy = vi.spyOn(input, "focus");
+    const selectSpy = vi.spyOn(input, "select");
+    input.value = "login";
+    input.dispatchEvent(new Event("input"));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+
+    const resultButton = Array.from(modal.contentEl.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("LOC-1"),
+    ) as HTMLButtonElement;
+    resultButton.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(focusSpy).toHaveBeenCalled();
+    expect(selectSpy).toHaveBeenCalled();
+  });
+});

--- a/src/search-modal.test.ts
+++ b/src/search-modal.test.ts
@@ -43,6 +43,14 @@ async function flush() {
   await Promise.resolve();
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("SearchModal", () => {
   it("renders title, helper text, and server-search button", () => {
     const modal = createModal();
@@ -110,6 +118,31 @@ describe("SearchModal", () => {
 
     expect(searchIssues).toHaveBeenCalledWith("server", 20);
     expect(modal.contentEl.textContent).toContain("SRV-3 — Keyboard result");
+  });
+
+  it("ignores stale server results after the user keeps typing locally", async () => {
+    const pending = deferred<Result<Issue[], never>>();
+    const searchIssues = vi.fn(async () => pending.promise);
+    const modal = createModal({
+      client: createClient({ searchIssues }),
+      localIssues: [issue("LOC-1", "Local alpha"), issue("LOC-2", "Local beta")],
+    });
+    modal.onOpen();
+
+    const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+    input.value = "alpha";
+    input.dispatchEvent(new Event("input"));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true }));
+    await flush();
+
+    input.value = "beta";
+    input.dispatchEvent(new Event("input"));
+    pending.resolve(ok([issue("SRV-9", "Server alpha")] as Issue[]));
+    await flush();
+
+    expect(modal.contentEl.textContent).toContain("LOC-2 — Local beta");
+    expect(modal.contentEl.textContent).not.toContain("SRV-9 — Server alpha");
+    expect(modal.contentEl.textContent).toContain("Showing local stub matches.");
   });
 
   it("inserts the first selected result on Enter from the input", async () => {

--- a/src/search-modal.ts
+++ b/src/search-modal.ts
@@ -90,6 +90,7 @@ export class SearchModal extends Modal {
   }
 
   private renderLocalResults(): void {
+    this.requestSeq += 1;
     this.mode = "local";
     this.loading = false;
     this.results = searchLocalIssues(this.localIssues, this.inputEl.value, RESULT_LIMIT);

--- a/src/search-modal.ts
+++ b/src/search-modal.ts
@@ -1,0 +1,288 @@
+import { App, Modal, Notice } from "obsidian";
+import type { Issue, JiraClient, JiraError } from "./jira-client";
+import {
+  getInputKeyAction,
+  getResultKeyAction,
+  isIssueKey,
+  searchLocalIssues,
+  type SearchIssue,
+} from "./search-helpers";
+
+const RESULT_LIMIT = 20;
+
+export interface SearchModalOptions {
+  app: App;
+  client: JiraClient;
+  loadLocalIssues: () => SearchIssue[];
+  onInsert: (issue: Issue) => void | Promise<void>;
+  onOpenIssue: (issue: Issue) => void | Promise<void>;
+}
+
+export class SearchModal extends Modal {
+  private readonly client: JiraClient;
+  private readonly loadLocalIssues: () => Issue[];
+  private readonly onInsertIssue: (issue: Issue) => void | Promise<void>;
+  private readonly onOpenIssueInBrowser: (issue: Issue) => void | Promise<void>;
+  private inputEl!: HTMLInputElement;
+  private resultsEl!: HTMLElement;
+  private helperEl!: HTMLElement;
+  private serverHintEl!: HTMLElement;
+  private statusEl!: HTMLElement;
+  private searchButtonEl!: HTMLButtonElement;
+  private localIssues: SearchIssue[] = [];
+  private results: Issue[] = [];
+  private resultButtons: HTMLButtonElement[] = [];
+  private selectedIndex = -1;
+  private mode: "local" | "server" = "local";
+  private requestSeq = 0;
+  private loading = false;
+  private reportedKinds = new Set<string>();
+  private sizeClassEl: HTMLElement | null = null;
+
+  constructor(opts: SearchModalOptions) {
+    super(opts.app);
+    this.client = opts.client;
+    this.loadLocalIssues = opts.loadLocalIssues;
+    this.onInsertIssue = opts.onInsert;
+    this.onOpenIssueInBrowser = opts.onOpenIssue;
+  }
+
+  onOpen(): void {
+    this.titleEl.setText("JIRA: Search issues");
+    this.sizeClassEl = this.modalEl instanceof HTMLElement ? this.modalEl : this.contentEl;
+    this.sizeClassEl.classList.add("jb-search-modal");
+    this.localIssues = this.loadLocalIssues();
+
+    const controlsEl = this.contentEl.createDiv({ cls: "jb-search-controls" });
+    this.inputEl = controlsEl.createEl("input", {
+      cls: "jb-search-input",
+      attr: { type: "text", placeholder: "Issue key, text, or JQL" },
+    });
+    this.searchButtonEl = controlsEl.createEl("button", {
+      cls: "mod-cta",
+      text: "Search on server",
+      attr: { type: "button" },
+    });
+
+    this.helperEl = this.contentEl.createDiv({
+      cls: "jb-search-helper",
+      text:
+        "Search local stubs instantly. Press Cmd-Enter or click Search on server for live JIRA results. JQL is passed through when detected.",
+    });
+    this.serverHintEl = this.contentEl.createDiv({ cls: "jb-search-server-hint" });
+    this.statusEl = this.contentEl.createDiv({ cls: "jb-search-status" });
+    this.resultsEl = this.contentEl.createDiv({ cls: "jb-search-results" });
+
+    this.inputEl.addEventListener("input", () => this.renderLocalResults());
+    this.inputEl.addEventListener("keydown", (evt) => this.onInputKeydown(evt));
+    this.searchButtonEl.addEventListener("click", () => {
+      void this.runServerSearch();
+    });
+
+    this.renderLocalResults();
+    this.inputEl.focus();
+  }
+
+  onClose(): void {
+    this.sizeClassEl?.classList.remove("jb-search-modal");
+    this.sizeClassEl = null;
+    this.contentEl.empty();
+  }
+
+  private renderLocalResults(): void {
+    this.mode = "local";
+    this.loading = false;
+    this.results = searchLocalIssues(this.localIssues, this.inputEl.value, RESULT_LIMIT);
+    this.selectedIndex = this.results.length > 0 ? 0 : -1;
+    this.renderResults();
+  }
+
+  private async runServerSearch(): Promise<void> {
+    const query = this.inputEl.value.trim();
+    if (!query || this.loading) return;
+
+    const seq = ++this.requestSeq;
+    this.mode = "server";
+    this.loading = true;
+    this.results = [];
+    this.selectedIndex = -1;
+    this.renderResults();
+
+    const result = isIssueKey(query)
+      ? await this.client.getIssue(query).then((r) =>
+          r.ok ? ({ ok: true as const, value: [r.value] }) : r,
+        )
+      : await this.client.searchIssues(query, RESULT_LIMIT);
+
+    if (seq !== this.requestSeq) return;
+
+    this.loading = false;
+    if (!result.ok) {
+      this.reportError(result.error);
+      this.results = [];
+      this.selectedIndex = -1;
+      this.renderResults();
+      return;
+    }
+
+    this.results = result.value;
+    this.selectedIndex = this.results.length > 0 ? 0 : -1;
+    this.renderResults();
+  }
+
+  private renderResults(): void {
+    const query = this.inputEl.value.trim();
+    this.searchButtonEl.disabled = this.loading || query.length === 0;
+    this.serverHintEl.setText(
+      query && this.mode === "local" ? "Cmd-Enter to search on server" : "",
+    );
+
+    this.statusEl.empty();
+    if (this.loading) {
+      this.statusEl.setText("Searching JIRA...");
+    } else if (!query) {
+      this.statusEl.setText("Type to search local stubs.");
+    } else if (this.results.length === 0) {
+      this.statusEl.setText(
+        this.mode === "server" ? "No server results." : "No local stub matches.",
+      );
+    } else {
+      this.statusEl.setText(
+        this.mode === "server"
+          ? "Showing live JIRA server results."
+          : "Showing local stub matches.",
+      );
+    }
+
+    this.resultsEl.empty();
+    this.resultButtons = [];
+
+    this.results.forEach((issue, index) => {
+      const button = this.resultsEl.createEl("button", {
+        cls: "jb-search-result",
+        attr: { type: "button" },
+      });
+      button.createEl("div", {
+        cls: "jb-search-result-title",
+        text: `${issue.key} — ${issue.summary}`,
+      });
+      const meta = [issue.type, issue.status].filter(Boolean).join(" · ");
+      if (meta) {
+        button.createEl("small", { cls: "jb-search-result-meta", text: meta });
+      }
+      button.addEventListener("click", () => {
+        void this.insertIssue(issue);
+      });
+      button.addEventListener("keydown", (evt) => this.onResultKeydown(evt, index));
+      this.resultButtons.push(button);
+    });
+
+    this.updateSelectedButton(false);
+  }
+
+  private updateSelectedButton(shouldFocus: boolean): void {
+    this.resultButtons.forEach((button, index) => {
+      button.classList.toggle("is-selected", index === this.selectedIndex);
+      button.setAttribute("aria-selected", index === this.selectedIndex ? "true" : "false");
+    });
+
+    if (shouldFocus && this.selectedIndex >= 0) {
+      this.resultButtons[this.selectedIndex]?.focus();
+    }
+  }
+
+  private onInputKeydown(evt: KeyboardEvent): void {
+    const action = getInputKeyAction(evt, { hasResults: this.results.length > 0 });
+    if (action === "none") return;
+    evt.preventDefault();
+
+    switch (action) {
+      case "close":
+        this.close();
+        return;
+      case "search-server":
+        void this.runServerSearch();
+        return;
+      case "select-first":
+        this.selectedIndex = 0;
+        this.updateSelectedButton(true);
+        return;
+      case "select-last":
+        this.selectedIndex = this.results.length - 1;
+        this.updateSelectedButton(true);
+        return;
+      case "insert-first":
+        if (this.selectedIndex < 0) return;
+        void this.insertIssue(this.results[this.selectedIndex]);
+        return;
+    }
+  }
+
+  private onResultKeydown(evt: KeyboardEvent, index: number): void {
+    const action = getResultKeyAction(evt);
+    if (action === "none") return;
+    evt.preventDefault();
+
+    switch (action) {
+      case "focus-input":
+        this.inputEl.focus();
+        this.inputEl.select();
+        return;
+      case "move-next":
+        this.selectedIndex = Math.min(index + 1, this.results.length - 1);
+        this.updateSelectedButton(true);
+        return;
+      case "move-prev":
+        this.selectedIndex = Math.max(index - 1, 0);
+        this.updateSelectedButton(true);
+        return;
+      case "insert":
+        void this.insertIssue(this.results[index]);
+        return;
+      case "open":
+        void this.openIssue(this.results[index]);
+        return;
+    }
+  }
+
+  private async insertIssue(issue: Issue): Promise<void> {
+    await this.onInsertIssue(issue);
+    this.close();
+  }
+
+  private async openIssue(issue: Issue): Promise<void> {
+    await this.onOpenIssueInBrowser(issue);
+    this.close();
+  }
+
+  private reportError(err: JiraError): void {
+    const dedupKey = err.kind === "not-found" ? `not-found:${err.key}` : err.kind;
+    if (this.reportedKinds.has(dedupKey)) return;
+    this.reportedKinds.add(dedupKey);
+
+    switch (err.kind) {
+      case "no-token":
+        new Notice("Set your JIRA Personal Access Token in plugin settings.");
+        return;
+      case "auth":
+        new Notice(`Authentication failed (HTTP ${err.status}). Check your PAT.`);
+        return;
+      case "network":
+        new Notice(`Could not reach JIRA: ${err.message}.`);
+        return;
+      case "not-found":
+        new Notice(`Issue ${err.key} not found.`);
+        return;
+      case "http":
+        if (err.status === 400) {
+          new Notice("JIRA search failed (HTTP 400). Check that your query is valid.");
+        } else {
+          new Notice(`JIRA returned HTTP ${err.status}: ${err.message}.`);
+        }
+        return;
+      case "parse":
+        new Notice("Unexpected response from JIRA.");
+        return;
+    }
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -104,3 +104,89 @@
   font-style: italic;
   margin-top: 4px;
 }
+
+.jb-search-modal {
+  width: min(1100px, calc(100vw - 96px));
+  max-width: min(1100px, calc(100vw - 96px));
+}
+
+.jb-search-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.jb-search-input {
+  flex: 1;
+}
+
+.jb-search-helper,
+.jb-search-server-hint,
+.jb-search-status {
+  margin-top: 8px;
+  font-size: var(--font-ui-small);
+}
+
+.jb-search-helper,
+.jb-search-status {
+  color: var(--text-muted);
+}
+
+.jb-search-server-hint {
+  color: var(--text-accent);
+  font-weight: 600;
+}
+
+.jb-search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.jb-search-result {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 6px;
+  box-sizing: border-box;
+  min-height: 0;
+  height: auto;
+  text-align: left;
+  line-height: normal;
+  padding: 14px 16px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+  white-space: normal;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.jb-search-result:hover,
+.jb-search-result.is-selected {
+  background: var(--background-modifier-hover);
+  border-color: var(--interactive-accent);
+}
+
+.jb-search-result-title {
+  width: 100%;
+  font-weight: 600;
+  font-size: var(--font-ui-medium);
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.jb-search-result-meta {
+  display: block;
+  width: 100%;
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary
- add a dedicated JIRA search command with local stub matches and explicit server search
- broaden local search coverage to the full stub metadata set used by preview/sidebar surfaces
- fix modal result overflow and bump the plugin to 1.1.2

Closes #33