### PR TITLE
JB-21: add issue key toggle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Open the command palette and run **JIRA: Insert issue link**. Type any part of t
 
 To wrap an existing selection, select the text first, then run **JIRA: Insert issue link** — the suggestion modal will use your selection as the seed search.
 
+To flip an exact issue key back and forth with your configured link template, run **JIRA: Toggle issue key / templated link** with the cursor on a bare key, markdown link, or wikilink. This is especially handy when your link template renders Obsidian wikilinks to synced stub notes.
+
 ### 3a. Search issues from the palette
 
 Open the command palette and run **JIRA: Search issues…**. As you type, the modal searches your local stub notes immediately. Press **Cmd-Enter** or click **Search on server** to replace those local matches with live JIRA results; JQL is passed through when detected. Press **Enter** on a selected result to insert it with your standard link template, or **Cmd-Enter** on a selected result to open it in the browser.
@@ -103,6 +105,7 @@ For one-off lookups without inserting a link, run **JIRA: Look up issue…** and
 | :--- | :--- |
 | **JIRA: Test connection** | Calls `/rest/api/2/myself`. Returns the authenticated user. |
 | **JIRA: Insert issue link** | Fuzzy-pick an issue and insert a markdown link using your *Link template*. Works on the current selection too. |
+| **JIRA: Toggle issue key / templated link** | Toggles the exact JIRA reference at the cursor between a bare issue key and your configured *Link template* output, including wikilink templates. |
 | **JIRA: Search issues…** | Search local stub notes instantly, then press Cmd-Enter or click **Search on server** for live JIRA results. Enter inserts the selected issue; Cmd-Enter opens it in the browser. |
 | **JIRA: Sync issue stubs** | Scans the vault for JIRA references, fetches fields, writes/updates stubs in your *Stubs folder*. |
 | **JIRA: Clean orphaned stubs** | Deletes stub notes whose issue is no longer referenced anywhere in the vault. |

--- a/src/jira-key.test.ts
+++ b/src/jira-key.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from "vitest";
 import {
+  classifyIssueReference,
+  extractKeyFromWikilink,
   parseKeyOrUrl,
   extractKeyFromHref,
   findKeyInText,
   findKeyAtCol,
   findLinkAtCol,
+  findWikilinkAtCol,
   parseMarkdownLink,
+  parseWikilink,
 } from "./jira-key";
 
 describe("parseKeyOrUrl", () => {
@@ -114,6 +118,40 @@ describe("parseMarkdownLink", () => {
   });
 });
 
+describe("parseWikilink", () => {
+  it("parses a simple wikilink", () => {
+    expect(parseWikilink("[[JIRA/ABC-1 Summary]]")).toEqual({
+      target: "JIRA/ABC-1 Summary",
+      alias: null,
+    });
+  });
+
+  it("parses a wikilink with an alias", () => {
+    expect(parseWikilink("  [[JIRA/ABC-1 Summary|ABC-1]]  ")).toEqual({
+      target: "JIRA/ABC-1 Summary",
+      alias: "ABC-1",
+    });
+  });
+
+  it("returns null for bare text", () => {
+    expect(parseWikilink("ABC-1")).toBeNull();
+  });
+});
+
+describe("extractKeyFromWikilink", () => {
+  it("prefers a key in the target", () => {
+    expect(
+      extractKeyFromWikilink({ target: "JIRA/ABC-1 Summary", alias: "Something else" }),
+    ).toBe("ABC-1");
+  });
+
+  it("falls back to the alias", () => {
+    expect(extractKeyFromWikilink({ target: "JIRA/Some summary", alias: "ABC-1" })).toBe(
+      "ABC-1",
+    );
+  });
+});
+
 describe("findLinkAtCol", () => {
   const line = "text [SRE-1](https://jira.me.com/browse/SRE-1) more";
   //            0123456789012345678901234567890123456789012345678901
@@ -143,5 +181,50 @@ describe("findLinkAtCol", () => {
     const l = "[a](u1) [b](u2)";
     const hit = findLinkAtCol(l, 10);
     expect(hit).toEqual({ text: "b", url: "u2", start: 8, end: 15 });
+  });
+});
+
+describe("findWikilinkAtCol", () => {
+  const line = "text [[JIRA/SRE-1 Summary|SRE-1]] more";
+
+  it("matches when col is inside the wikilink", () => {
+    const hit = findWikilinkAtCol(line, 12);
+    expect(hit).toEqual({
+      target: "JIRA/SRE-1 Summary",
+      alias: "SRE-1",
+      start: 5,
+      end: 33,
+    });
+  });
+
+  it("returns null when col is outside any wikilink", () => {
+    expect(findWikilinkAtCol(line, 2)).toBeNull();
+    expect(findWikilinkAtCol(line, 38)).toBeNull();
+  });
+});
+
+describe("classifyIssueReference", () => {
+  const base = "https://jira.me.com";
+
+  it("classifies an exact bare key", () => {
+    expect(classifyIssueReference("ABC-1", base)).toEqual({ kind: "key", key: "ABC-1" });
+  });
+
+  it("classifies an exact markdown link", () => {
+    expect(classifyIssueReference("[ABC-1](https://jira.me.com/browse/ABC-1)", base)).toEqual({
+      kind: "link",
+      key: "ABC-1",
+    });
+  });
+
+  it("classifies an exact wikilink", () => {
+    expect(classifyIssueReference("[[JIRA/ABC-1 Summary|ABC-1]]", base)).toEqual({
+      kind: "link",
+      key: "ABC-1",
+    });
+  });
+
+  it("ignores arbitrary prose that only mentions a key", () => {
+    expect(classifyIssueReference("see ABC-1 today", base)).toBeNull();
   });
 });

--- a/src/jira-key.test.ts
+++ b/src/jira-key.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   classifyIssueReference,
+  classifyRewriteIssueReference,
   extractKeyFromWikilink,
   parseKeyOrUrl,
   extractKeyFromHref,
@@ -226,5 +227,38 @@ describe("classifyIssueReference", () => {
 
   it("ignores arbitrary prose that only mentions a key", () => {
     expect(classifyIssueReference("see ABC-1 today", base)).toBeNull();
+  });
+});
+
+describe("classifyRewriteIssueReference", () => {
+  const base = "https://jira.me.com";
+
+  it("classifies an exact bare key", () => {
+    expect(classifyRewriteIssueReference("ABC-1", base)).toEqual({
+      kind: "key",
+      key: "ABC-1",
+    });
+  });
+
+  it("classifies an exact JIRA markdown link", () => {
+    expect(
+      classifyRewriteIssueReference("[ABC-1](https://jira.me.com/browse/ABC-1)", base),
+    ).toEqual({
+      kind: "link",
+      key: "ABC-1",
+    });
+  });
+
+  it("rejects markdown links whose href is not the configured JIRA host", () => {
+    expect(
+      classifyRewriteIssueReference("[ABC-1](https://elsewhere.example.com/docs/ABC-1)", base),
+    ).toBeNull();
+  });
+
+  it("classifies an exact wikilink", () => {
+    expect(classifyRewriteIssueReference("[[JIRA/ABC-1 Summary|ABC-1]]", base)).toEqual({
+      kind: "link",
+      key: "ABC-1",
+    });
   });
 });

--- a/src/jira-key.ts
+++ b/src/jira-key.ts
@@ -115,6 +115,32 @@ export function classifyIssueReference(
   return null;
 }
 
+export function classifyRewriteIssueReference(
+  text: string,
+  baseUrl: string,
+): { kind: "key" | "link"; key: string } | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (KEY_RE.test(trimmed)) {
+    return { kind: "key", key: trimmed };
+  }
+
+  const markdown = parseMarkdownLink(trimmed);
+  if (markdown) {
+    const key = extractKeyFromHref(markdown.url, baseUrl);
+    if (key) return { kind: "link", key };
+    return null;
+  }
+
+  const wikilink = parseWikilink(trimmed);
+  if (wikilink) {
+    const key = extractKeyFromWikilink(wikilink);
+    if (key) return { kind: "link", key };
+  }
+
+  return null;
+}
+
 /**
  * Find a JIRA key whose span covers `col` in `line`. The cursor is considered
  * "on" a key when it sits at the start, end, or anywhere inside the key. Returns

--- a/src/jira-key.ts
+++ b/src/jira-key.ts
@@ -30,12 +30,28 @@ const KEY_GLOBAL_RE = /\b[A-Z][A-Z0-9]+-\d+\b/g;
 
 const MD_LINK_GLOBAL_RE = /\[([^\]\n]*)\]\(([^)\s]+)\)/g;
 const MD_LINK_ANCHORED_RE = /^\[([^\]\n]*)\]\(([^)\s]+)\)$/;
+const WIKILINK_GLOBAL_RE = /\[\[([^|\]\n]+)(?:\|([^\]\n]*))?\]\]/g;
+const WIKILINK_ANCHORED_RE = /^\[\[([^|\]\n]+)(?:\|([^\]\n]*))?\]\]$/;
 
 export function parseMarkdownLink(
   text: string,
 ): { text: string; url: string } | null {
   const m = text.trim().match(MD_LINK_ANCHORED_RE);
   return m ? { text: m[1], url: m[2] } : null;
+}
+
+export function parseWikilink(
+  text: string,
+): { target: string; alias: string | null } | null {
+  const m = text.trim().match(WIKILINK_ANCHORED_RE);
+  return m ? { target: m[1], alias: m[2] ?? null } : null;
+}
+
+export function extractKeyFromWikilink(link: {
+  target: string;
+  alias: string | null;
+}): string | null {
+  return findKeyInText(link.target) ?? (link.alias ? findKeyInText(link.alias) : null);
 }
 
 /**
@@ -55,6 +71,47 @@ export function findLinkAtCol(
       return { text: m[1], url: m[2], start, end };
     }
   }
+  return null;
+}
+
+export function findWikilinkAtCol(
+  line: string,
+  col: number,
+): { target: string; alias: string | null; start: number; end: number } | null {
+  WIKILINK_GLOBAL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WIKILINK_GLOBAL_RE.exec(line))) {
+    const start = m.index;
+    const end = start + m[0].length;
+    if (col >= start && col <= end) {
+      return { target: m[1], alias: m[2] ?? null, start, end };
+    }
+  }
+  return null;
+}
+
+export function classifyIssueReference(
+  text: string,
+  baseUrl: string,
+): { kind: "key" | "link"; key: string } | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (KEY_RE.test(trimmed)) {
+    return { kind: "key", key: trimmed };
+  }
+
+  const markdown = parseMarkdownLink(trimmed);
+  if (markdown) {
+    const key = extractKeyFromHref(markdown.url, baseUrl) ?? findKeyInText(markdown.text);
+    if (key) return { kind: "link", key };
+  }
+
+  const wikilink = parseWikilink(trimmed);
+  if (wikilink) {
+    const key = extractKeyFromWikilink(wikilink);
+    if (key) return { kind: "link", key };
+  }
+
   return null;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ import { createIssueService, IssueService } from "./issue-service";
 import { registerHoverPreview } from "./hover-preview";
 import { LookupModal } from "./lookup-modal";
 import {
-  classifyIssueReference,
+  classifyRewriteIssueReference,
   findKeyAtCol,
   findKeyInText,
   findLinkAtCol,
@@ -568,13 +568,16 @@ export default class JiraBasesPlugin extends Plugin {
     const markdownLink = findLinkAtCol(line, cursor.ch);
     if (
       markdownLink &&
-      classifyIssueReference(line.slice(markdownLink.start, markdownLink.end), baseUrl)
+      classifyRewriteIssueReference(line.slice(markdownLink.start, markdownLink.end), baseUrl)
     ) {
       return selectRange(markdownLink.start, markdownLink.end);
     }
 
     const wikilink = findWikilinkAtCol(line, cursor.ch);
-    if (wikilink && classifyIssueReference(line.slice(wikilink.start, wikilink.end), baseUrl)) {
+    if (
+      wikilink &&
+      classifyRewriteIssueReference(line.slice(wikilink.start, wikilink.end), baseUrl)
+    ) {
       return selectRange(wikilink.start, wikilink.end);
     }
 
@@ -602,7 +605,7 @@ export default class JiraBasesPlugin extends Plugin {
 
     // Case A0: selection is an existing markdown link or wikilink pointing at
     // a JIRA issue — reformat it to the configured linkTemplate.
-    const exactReference = selection ? classifyIssueReference(selection, baseUrl) : null;
+    const exactReference = selection ? classifyRewriteIssueReference(selection, baseUrl) : null;
     if (exactReference?.kind === "link") {
       const r = await client.getIssueDetails(exactReference.key);
       if (!r.ok) {
@@ -672,7 +675,7 @@ export default class JiraBasesPlugin extends Plugin {
     }
 
     const selection = this.expandSelectionToIssueReference(editor, baseUrl);
-    const reference = selection ? classifyIssueReference(selection, baseUrl) : null;
+    const reference = selection ? classifyRewriteIssueReference(selection, baseUrl) : null;
     if (!reference) {
       new Notice("Select a JIRA issue key or place the cursor on an exact JIRA link.");
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,11 +39,11 @@ import { createIssueService, IssueService } from "./issue-service";
 import { registerHoverPreview } from "./hover-preview";
 import { LookupModal } from "./lookup-modal";
 import {
-  extractKeyFromHref,
+  classifyIssueReference,
   findKeyAtCol,
   findKeyInText,
   findLinkAtCol,
-  parseMarkdownLink,
+  findWikilinkAtCol,
 } from "./jira-key";
 import { CommentIssueSuggestModal } from "./comment-issue-modal";
 import { createFailedKeysTracker, FailedKeysTracker } from "./failed-keys-tracker";
@@ -164,6 +164,12 @@ export default class JiraBasesPlugin extends Plugin {
       id: "insert-issue-link",
       name: "JIRA: Insert issue link",
       editorCallback: (editor) => this.insertIssueLink(editor),
+    });
+
+    this.addCommand({
+      id: "toggle-issue-key-template-link",
+      name: "JIRA: Toggle issue key / templated link",
+      editorCallback: (editor) => this.toggleIssueKeyTemplateLink(editor),
     });
 
     this.addCommand({
@@ -545,6 +551,41 @@ export default class JiraBasesPlugin extends Plugin {
     this.setupStatusBar();
   }
 
+  private expandSelectionToIssueReference(editor: Editor, baseUrl: string): string {
+    let selection = editor.getSelection();
+    if (selection) return selection;
+
+    const cursor = editor.getCursor();
+    const line = editor.getLine(cursor.line);
+    const selectRange = (start: number, end: number): string => {
+      editor.setSelection(
+        { line: cursor.line, ch: start },
+        { line: cursor.line, ch: end },
+      );
+      return line.slice(start, end);
+    };
+
+    const markdownLink = findLinkAtCol(line, cursor.ch);
+    if (
+      markdownLink &&
+      classifyIssueReference(line.slice(markdownLink.start, markdownLink.end), baseUrl)
+    ) {
+      return selectRange(markdownLink.start, markdownLink.end);
+    }
+
+    const wikilink = findWikilinkAtCol(line, cursor.ch);
+    if (wikilink && classifyIssueReference(line.slice(wikilink.start, wikilink.end), baseUrl)) {
+      return selectRange(wikilink.start, wikilink.end);
+    }
+
+    const hit = findKeyAtCol(line, cursor.ch);
+    if (hit) {
+      return selectRange(hit.start, hit.end);
+    }
+
+    return selection;
+  }
+
   async insertIssueLink(editor: Editor): Promise<void> {
     const baseUrl = this.settings.baseUrl;
     if (!baseUrl) {
@@ -555,56 +596,27 @@ export default class JiraBasesPlugin extends Plugin {
     // Establish the effective selection. If the editor has a real selection,
     // honor it; otherwise, if the cursor is on a JIRA key, expand to that key.
     const baseStripped = baseUrl.replace(/\/+$/, "");
-    let selection = editor.getSelection();
-    if (!selection) {
-      const cursor = editor.getCursor();
-      const line = editor.getLine(cursor.line);
-      const link = findLinkAtCol(line, cursor.ch);
-      const linkKey = link
-        ? (extractKeyFromHref(link.url, baseUrl) ?? findKeyInText(link.text))
-        : null;
-      if (link && linkKey) {
-        editor.setSelection(
-          { line: cursor.line, ch: link.start },
-          { line: cursor.line, ch: link.end },
-        );
-        selection = line.slice(link.start, link.end);
-      } else {
-        const hit = findKeyAtCol(line, cursor.ch);
-        if (hit) {
-          editor.setSelection(
-            { line: cursor.line, ch: hit.start },
-            { line: cursor.line, ch: hit.end },
-          );
-          selection = hit.key;
-        }
-      }
-    }
+    const selection = this.expandSelectionToIssueReference(editor, baseUrl);
 
     const client = this.makeClient();
 
-    // Case A0: selection is an existing markdown link pointing at a JIRA
-    // issue — reformat it to the configured linkTemplate.
-    if (selection) {
-      const parsed = parseMarkdownLink(selection);
-      const linkKey = parsed
-        ? (extractKeyFromHref(parsed.url, baseUrl) ??
-          findKeyInText(parsed.text))
-        : null;
-      if (parsed && linkKey) {
-        const r = await client.getIssueDetails(linkKey);
-        if (!r.ok) {
-          new Notice(errorMessage(r.error));
-          return;
-        }
-        editor.replaceSelection(
-          renderTemplate(this.settings.linkTemplate, escapeIssueDetailsForTemplate(r.value)),
-        );
+    // Case A0: selection is an existing markdown link or wikilink pointing at
+    // a JIRA issue — reformat it to the configured linkTemplate.
+    const exactReference = selection ? classifyIssueReference(selection, baseUrl) : null;
+    if (exactReference?.kind === "link") {
+      const r = await client.getIssueDetails(exactReference.key);
+      if (!r.ok) {
+        new Notice(errorMessage(r.error));
         return;
       }
+      editor.replaceSelection(
+        renderTemplate(this.settings.linkTemplate, escapeIssueDetailsForTemplate(r.value)),
+      );
+      return;
     }
 
-    const detectedKey = selection ? findKeyInText(selection) : null;
+    const detectedKey =
+      exactReference?.kind === "key" ? exactReference.key : selection ? findKeyInText(selection) : null;
 
     // Case A: we know the key. If the selection is just the bare key, render
     // the configured linkTemplate (we need the issue's summary etc.).
@@ -650,6 +662,36 @@ export default class JiraBasesPlugin extends Plugin {
       },
     });
     modal.open();
+  }
+
+  async toggleIssueKeyTemplateLink(editor: Editor): Promise<void> {
+    const baseUrl = this.settings.baseUrl;
+    if (!baseUrl) {
+      new Notice("Set your JIRA base URL in plugin settings.");
+      return;
+    }
+
+    const selection = this.expandSelectionToIssueReference(editor, baseUrl);
+    const reference = selection ? classifyIssueReference(selection, baseUrl) : null;
+    if (!reference) {
+      new Notice("Select a JIRA issue key or place the cursor on an exact JIRA link.");
+      return;
+    }
+
+    if (reference.kind === "link") {
+      editor.replaceSelection(reference.key);
+      return;
+    }
+
+    const result = await this.makeClient().getIssueDetails(reference.key);
+    if (!result.ok) {
+      new Notice(errorMessage(result.error));
+      return;
+    }
+
+    editor.replaceSelection(
+      renderTemplate(this.settings.linkTemplate, escapeIssueDetailsForTemplate(result.value)),
+    );
   }
 
   private collectStubIssues(): SearchIssue[] {

--- a/src/ref-scanner.test.ts
+++ b/src/ref-scanner.test.ts
@@ -35,6 +35,18 @@ describe("findReferences — link form", () => {
     const refs = findReferences(content, BASE, []);
     expect([...refs]).toEqual(["ABC-1"]);
   });
+
+  it("captures keys from wikilinks without requiring prefixes", () => {
+    const content = "See [[JIRA/ABC-123 Summary|ABC-123]].";
+    const refs = findReferences(content, BASE, []);
+    expect([...refs]).toEqual(["ABC-123"]);
+  });
+
+  it("captures keys from wikilink targets when alias omits the key", () => {
+    const content = "See [[JIRA/ABC-123 Summary|Follow-up note]].";
+    const refs = findReferences(content, BASE, []);
+    expect([...refs]).toEqual(["ABC-123"]);
+  });
 });
 
 describe("findReferences — bare key form", () => {

--- a/src/ref-scanner.ts
+++ b/src/ref-scanner.ts
@@ -1,3 +1,5 @@
+import { extractKeyFromWikilink, parseWikilink } from "./jira-key";
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -22,6 +24,13 @@ export function findReferences(
     for (const m of content.matchAll(linkRe)) {
       found.add(m[1].toUpperCase());
     }
+  }
+
+  const wikilinkRe = /\[\[[^\]\n]+\]\]/g;
+  for (const m of content.matchAll(wikilinkRe)) {
+    const parsed = parseWikilink(m[0]);
+    const key = parsed ? extractKeyFromWikilink(parsed) : null;
+    if (key) found.add(key.toUpperCase());
   }
 
   const valid = prefixes.filter((p) => /^[A-Z][A-Z0-9]+$/.test(p));

--- a/src/resolve-issue-key.test.ts
+++ b/src/resolve-issue-key.test.ts
@@ -64,6 +64,16 @@ describe("resolveIssueKey", () => {
     expect(r).toBe("SRE-1");
   });
 
+  it("resolves a key from a wikilink under the cursor", () => {
+    const line = "text [[JIRA/SRE-1 Summary|SRE-1]] more";
+    const r = resolveIssueKey({
+      editor: fakeEditor({ cursor: { line: 0, ch: 12 }, lines: [line] }),
+      activeFileFrontmatter: null,
+      baseUrl: BASE,
+    });
+    expect(r).toBe("SRE-1");
+  });
+
   it("falls back to anchor text when href host doesn't match", () => {
     const line = `[ABC-2](https://elsewhere.com/x)`;
     const r = resolveIssueKey({

--- a/src/resolve-issue-key.ts
+++ b/src/resolve-issue-key.ts
@@ -1,8 +1,11 @@
 import {
+  classifyIssueReference,
+  extractKeyFromWikilink,
   extractKeyFromHref,
   findKeyAtCol,
   findKeyInText,
   findLinkAtCol,
+  findWikilinkAtCol,
   parseKeyOrUrl,
 } from "./jira-key";
 
@@ -27,7 +30,9 @@ export function resolveIssueKey(deps: ResolveIssueKeyDeps): string | null {
     const selection = editor.getSelection();
     if (selection) {
       const fromSelection =
-        parseKeyOrUrl(selection, baseUrl) ?? findKeyInText(selection);
+        classifyIssueReference(selection, baseUrl)?.key ??
+        parseKeyOrUrl(selection, baseUrl) ??
+        findKeyInText(selection);
       if (fromSelection) return fromSelection;
     }
     const cursor = editor.getCursor();
@@ -36,6 +41,11 @@ export function resolveIssueKey(deps: ResolveIssueKeyDeps): string | null {
     if (link) {
       const linkKey =
         extractKeyFromHref(link.url, baseUrl) ?? findKeyInText(link.text);
+      if (linkKey) return linkKey;
+    }
+    const wikilink = findWikilinkAtCol(line, cursor.ch);
+    if (wikilink) {
+      const linkKey = extractKeyFromWikilink(wikilink);
       if (linkKey) return linkKey;
     }
     const hit = findKeyAtCol(line, cursor.ch);


### PR DESCRIPTION
## Summary
- add a new `JIRA: Toggle issue key / templated link` command
- make issue-reference parsing and resolution understand exact Obsidian wikilinks
- scan wikilink references for stub-sync flows and document the new command

## Validation
- npm test
- npm run typecheck
- npm run build

Closes #37
