### PR TITLE
JB-21: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to **JIRA Bases** are recorded here. Releases follow [semver](https://semver.org/) and are auto-published to GitHub Releases when `manifest.json` / `package.json` versions change on `main`.
 
+## 1.2.0 — Toggle issue key / templated link (JB-21)
+
+- **New command.** Added **JIRA: Toggle issue key / templated link**, which flips the exact JIRA reference at the cursor between a bare issue key and the configured Link template output.
+- **Wikilink-aware rewrites.** Exact Obsidian wikilinks are now recognized alongside markdown links and bare keys, so templated stub-note links can round-trip cleanly.
+- **Safety hardening.** Rewrite-only detection now refuses markdown links whose href is not on the configured JIRA host, preventing unrelated links with key-looking text from being collapsed by the toggle flow.
+- **Downstream consistency.** Issue-key resolution and vault reference scanning now understand exact wikilinks too, so open/copy/sync flows stay aligned with the new command behavior.
+
 ## 1.1.1 — README — auto-lookup as a passive flow (JB-17)
 
 - **Docs.** Promotes auto-lookup-on-type from a one-line settings entry to a first-class flow in the README. Adds an Overview bullet, a Quick Start subsection, a Reference deep-dive (what it scans, what it skips, link styles, idle-pause tuning, interaction with stub sync and the JB-15 URL debounce), and a Troubleshooting entry covering the common "key didn't get linked" gotchas. No code changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to **JIRA Bases** are recorded here. Releases follow [semver](https://semver.org/) and are auto-published to GitHub Releases when `manifest.json` / `package.json` versions change on `main`.
+All notable changes to **JIRA Bases** are recorded here. Releases follow [semver](https://semver.org/) and are auto-published to GitHub Releases when the `manifest.json` version changes on `main`.
 
 ## 1.2.0 — Toggle issue key / templated link (JB-21)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the plugin version to `1.2.0` so JB-21 ships through the release workflow
- sync `package.json`, `package-lock.json`, and `manifest.json`
- add the JB-21 release note block to `CHANGELOG.md`

## Validation
- npm test
- npm run typecheck
- npm run build
