### PR TITLE
JB-21: fix partial wikilink toggle selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to **JIRA Bases** are recorded here. Releases follow [semver](https://semver.org/) and are auto-published to GitHub Releases when the `manifest.json` version changes on `main`.
 
+## 1.2.1 — Partial template-wikilink selection toggle fix (JB-21)
+
+- **Fix — partial selection expansion.** The shared reference-expansion path now widens a single-line partial selection that sits entirely inside a rewritable JIRA reference to the full span before classification.
+- **Templated wikilinks now toggle reliably.** Selecting only part of a template-generated Obsidian wikilink no longer misses the match; the toggle command resolves the enclosing wikilink and flips it back to the bare issue key as expected.
+- **Same-line safety.** Auto-expansion still stays bounded to one exact containing reference on one line, so unrelated prose selections and multi-line selections are left alone.
+
 ## 1.2.0 — Toggle issue key / templated link (JB-21)
 
 - **New command.** Added **JIRA: Toggle issue key / templated link**, which flips the exact JIRA reference at the cursor between a bare issue key and the configured Link template output.

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -13,6 +13,19 @@ export class Notice {
 
 export class App {}
 
+export class Plugin {
+  app: unknown;
+  manifest: unknown;
+  constructor(app: unknown, manifest?: unknown) {
+    this.app = app;
+    this.manifest = manifest;
+  }
+}
+
+export async function requestUrl(_request: unknown) {
+  throw new Error("requestUrl mock not implemented");
+}
+
 export class PluginSettingTab {
   app: unknown;
   containerEl = {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jira-bases",
   "name": "JIRA Bases",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "minAppVersion": "1.5.0",
   "description": "JIRA Data Center integration (PAT-only, desktop) for smart links, Bases metadata, and issue lookup. Not for JIRA Cloud.",
   "author": "Eugene Archibald",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-bases",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-bases",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-bases",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Obsidian plugin for JIRA Data Center: smart links, Bases metadata, issue lookup.",
   "main": "main.js",
   "scripts": {

--- a/src/jira-key.test.ts
+++ b/src/jira-key.test.ts
@@ -3,11 +3,14 @@ import {
   classifyIssueReference,
   classifyRewriteIssueReference,
   extractKeyFromWikilink,
+  findKeyContainingRange,
   parseKeyOrUrl,
   extractKeyFromHref,
   findKeyInText,
   findKeyAtCol,
+  findLinkContainingRange,
   findLinkAtCol,
+  findWikilinkContainingRange,
   findWikilinkAtCol,
   parseMarkdownLink,
   parseWikilink,
@@ -185,6 +188,32 @@ describe("findLinkAtCol", () => {
   });
 });
 
+describe("findLinkContainingRange", () => {
+  const line = "text [SRE-1](https://jira.me.com/browse/SRE-1) more";
+
+  it("matches an exact link selection", () => {
+    expect(findLinkContainingRange(line, 5, 46)).toEqual({
+      text: "SRE-1",
+      url: "https://jira.me.com/browse/SRE-1",
+      start: 5,
+      end: 46,
+    });
+  });
+
+  it("matches a partial selection inside the link", () => {
+    expect(findLinkContainingRange(line, 12, 18)).toEqual({
+      text: "SRE-1",
+      url: "https://jira.me.com/browse/SRE-1",
+      start: 5,
+      end: 46,
+    });
+  });
+
+  it("returns null when the selection extends outside the link", () => {
+    expect(findLinkContainingRange(line, 2, 10)).toBeNull();
+  });
+});
+
 describe("findWikilinkAtCol", () => {
   const line = "text [[JIRA/SRE-1 Summary|SRE-1]] more";
 
@@ -201,6 +230,56 @@ describe("findWikilinkAtCol", () => {
   it("returns null when col is outside any wikilink", () => {
     expect(findWikilinkAtCol(line, 2)).toBeNull();
     expect(findWikilinkAtCol(line, 38)).toBeNull();
+  });
+});
+
+describe("findWikilinkContainingRange", () => {
+  const line = "text [[JIRA/SRE-1 Summary|SRE-1]] more";
+
+  it("matches an exact wikilink selection", () => {
+    expect(findWikilinkContainingRange(line, 5, 33)).toEqual({
+      target: "JIRA/SRE-1 Summary",
+      alias: "SRE-1",
+      start: 5,
+      end: 33,
+    });
+  });
+
+  it("matches a partial selection inside the wikilink", () => {
+    expect(findWikilinkContainingRange(line, 15, 24)).toEqual({
+      target: "JIRA/SRE-1 Summary",
+      alias: "SRE-1",
+      start: 5,
+      end: 33,
+    });
+  });
+
+  it("returns null when the selection extends outside the wikilink", () => {
+    expect(findWikilinkContainingRange(line, 2, 12)).toBeNull();
+  });
+});
+
+describe("findKeyContainingRange", () => {
+  const line = "fix SRE-1235 today";
+
+  it("matches an exact key selection", () => {
+    expect(findKeyContainingRange(line, 4, 12)).toEqual({
+      key: "SRE-1235",
+      start: 4,
+      end: 12,
+    });
+  });
+
+  it("matches a partial selection inside the key", () => {
+    expect(findKeyContainingRange(line, 6, 10)).toEqual({
+      key: "SRE-1235",
+      start: 4,
+      end: 12,
+    });
+  });
+
+  it("returns null when the selection extends outside the key", () => {
+    expect(findKeyContainingRange(line, 2, 8)).toBeNull();
   });
 });
 

--- a/src/jira-key.test.ts
+++ b/src/jira-key.test.ts
@@ -211,6 +211,7 @@ describe("findLinkContainingRange", () => {
 
   it("returns null when the selection extends outside the link", () => {
     expect(findLinkContainingRange(line, 2, 10)).toBeNull();
+    expect(findLinkContainingRange(line, 5, 47)).toBeNull();
   });
 });
 
@@ -256,6 +257,7 @@ describe("findWikilinkContainingRange", () => {
 
   it("returns null when the selection extends outside the wikilink", () => {
     expect(findWikilinkContainingRange(line, 2, 12)).toBeNull();
+    expect(findWikilinkContainingRange(line, 5, 34)).toBeNull();
   });
 });
 
@@ -280,6 +282,7 @@ describe("findKeyContainingRange", () => {
 
   it("returns null when the selection extends outside the key", () => {
     expect(findKeyContainingRange(line, 2, 8)).toBeNull();
+    expect(findKeyContainingRange(line, 4, 13)).toBeNull();
   });
 });
 

--- a/src/jira-key.ts
+++ b/src/jira-key.ts
@@ -74,6 +74,23 @@ export function findLinkAtCol(
   return null;
 }
 
+export function findLinkContainingRange(
+  line: string,
+  startCh: number,
+  endCh: number,
+): { text: string; url: string; start: number; end: number } | null {
+  MD_LINK_GLOBAL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = MD_LINK_GLOBAL_RE.exec(line))) {
+    const start = m.index;
+    const end = start + m[0].length;
+    if (startCh >= start && endCh <= end) {
+      return { text: m[1], url: m[2], start, end };
+    }
+  }
+  return null;
+}
+
 export function findWikilinkAtCol(
   line: string,
   col: number,
@@ -84,6 +101,23 @@ export function findWikilinkAtCol(
     const start = m.index;
     const end = start + m[0].length;
     if (col >= start && col <= end) {
+      return { target: m[1], alias: m[2] ?? null, start, end };
+    }
+  }
+  return null;
+}
+
+export function findWikilinkContainingRange(
+  line: string,
+  startCh: number,
+  endCh: number,
+): { target: string; alias: string | null; start: number; end: number } | null {
+  WIKILINK_GLOBAL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WIKILINK_GLOBAL_RE.exec(line))) {
+    const start = m.index;
+    const end = start + m[0].length;
+    if (startCh >= start && endCh <= end) {
       return { target: m[1], alias: m[2] ?? null, start, end };
     }
   }
@@ -156,6 +190,21 @@ export function findKeyAtCol(
     const start = m.index;
     const end = start + m[0].length;
     if (col >= start && col <= end) return { key: m[0], start, end };
+  }
+  return null;
+}
+
+export function findKeyContainingRange(
+  line: string,
+  startCh: number,
+  endCh: number,
+): { key: string; start: number; end: number } | null {
+  KEY_GLOBAL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = KEY_GLOBAL_RE.exec(line))) {
+    const start = m.index;
+    const end = start + m[0].length;
+    if (startCh >= start && endCh <= end) return { key: m[0], start, end };
   }
   return null;
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import JiraBasesPlugin from "./main";
+
+type Cursor = { line: number; ch: number };
+
+function makeEditor(lines: string[], from: Cursor, to: Cursor) {
+  const calls: Array<{ from: Cursor; to: Cursor }> = [];
+  const selection =
+    from.line === to.line
+      ? lines[from.line].slice(from.ch, to.ch)
+      : `${lines[from.line].slice(from.ch)}\n${lines[to.line].slice(0, to.ch)}`;
+
+  return {
+    calls,
+    editor: {
+      getSelection: () => selection,
+      getCursor: (which?: "from" | "to") => (which === "from" ? from : to),
+      getLine: (line: number) => lines[line],
+      setSelection: (nextFrom: Cursor, nextTo: Cursor) => {
+        calls.push({ from: nextFrom, to: nextTo });
+      },
+    },
+  };
+}
+
+describe("expandSelectionToIssueReference", () => {
+  it("widens a partial selection inside a rewritable markdown link", () => {
+    const line = "text [SRE-1](https://jira.me.com/browse/SRE-1) more";
+    const { editor, calls } = makeEditor([line], { line: 0, ch: 12 }, { line: 0, ch: 18 });
+    const plugin = new JiraBasesPlugin({} as any, {} as any);
+
+    const expanded = (plugin as any).expandSelectionToIssueReference(
+      editor,
+      "https://jira.me.com",
+    );
+
+    expect(expanded).toBe("[SRE-1](https://jira.me.com/browse/SRE-1)");
+    expect(calls).toEqual([{ from: { line: 0, ch: 5 }, to: { line: 0, ch: 46 } }]);
+  });
+
+  it("does not fall through to bare-key expansion inside a non-JIRA markdown link", () => {
+    const line = "text [SRE-1](https://elsewhere.example.com/docs/SRE-1) more";
+    const { editor, calls } = makeEditor([line], { line: 0, ch: 12 }, { line: 0, ch: 18 });
+    const plugin = new JiraBasesPlugin({} as any, {} as any);
+
+    const expanded = (plugin as any).expandSelectionToIssueReference(
+      editor,
+      "https://jira.me.com",
+    );
+
+    expect(expanded).toBe(line.slice(12, 18));
+    expect(calls).toEqual([]);
+  });
+
+  it("leaves multi-line selections unchanged", () => {
+    const lines = [
+      "text [SRE-1](https://jira.me.com/browse/SRE-1)",
+      "next line",
+    ];
+    const { editor, calls } = makeEditor(lines, { line: 0, ch: 12 }, { line: 1, ch: 4 });
+    const plugin = new JiraBasesPlugin({} as any, {} as any);
+    const selection = editor.getSelection();
+
+    const expanded = (plugin as any).expandSelectionToIssueReference(
+      editor,
+      "https://jira.me.com",
+    );
+
+    expect(expanded).toBe(selection);
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -576,6 +576,9 @@ export default class JiraBasesPlugin extends Plugin {
         ) {
           return selectRange(markdownLink.start, markdownLink.end);
         }
+        if (markdownLink) {
+          return selection;
+        }
 
         const wikilink = findWikilinkContainingRange(line, from.ch, to.ch);
         if (
@@ -583,6 +586,9 @@ export default class JiraBasesPlugin extends Plugin {
           classifyRewriteIssueReference(line.slice(wikilink.start, wikilink.end), baseUrl)
         ) {
           return selectRange(wikilink.start, wikilink.end);
+        }
+        if (wikilink) {
+          return selection;
         }
 
         const key = findKeyContainingRange(line, from.ch, to.ch);

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,9 +40,12 @@ import { registerHoverPreview } from "./hover-preview";
 import { LookupModal } from "./lookup-modal";
 import {
   classifyRewriteIssueReference,
+  findKeyContainingRange,
   findKeyAtCol,
   findKeyInText,
+  findLinkContainingRange,
   findLinkAtCol,
+  findWikilinkContainingRange,
   findWikilinkAtCol,
 } from "./jira-key";
 import { CommentIssueSuggestModal } from "./comment-issue-modal";
@@ -553,7 +556,42 @@ export default class JiraBasesPlugin extends Plugin {
 
   private expandSelectionToIssueReference(editor: Editor, baseUrl: string): string {
     let selection = editor.getSelection();
-    if (selection) return selection;
+    if (selection) {
+      const from = editor.getCursor("from");
+      const to = editor.getCursor("to");
+      if (from.line === to.line) {
+        const line = editor.getLine(from.line);
+        const selectRange = (start: number, end: number): string => {
+          editor.setSelection(
+            { line: from.line, ch: start },
+            { line: from.line, ch: end },
+          );
+          return line.slice(start, end);
+        };
+
+        const markdownLink = findLinkContainingRange(line, from.ch, to.ch);
+        if (
+          markdownLink &&
+          classifyRewriteIssueReference(line.slice(markdownLink.start, markdownLink.end), baseUrl)
+        ) {
+          return selectRange(markdownLink.start, markdownLink.end);
+        }
+
+        const wikilink = findWikilinkContainingRange(line, from.ch, to.ch);
+        if (
+          wikilink &&
+          classifyRewriteIssueReference(line.slice(wikilink.start, wikilink.end), baseUrl)
+        ) {
+          return selectRange(wikilink.start, wikilink.end);
+        }
+
+        const key = findKeyContainingRange(line, from.ch, to.ch);
+        if (key) {
+          return selectRange(key.start, key.end);
+        }
+      }
+      return selection;
+    }
 
     const cursor = editor.getCursor();
     const line = editor.getLine(cursor.line);


### PR DESCRIPTION
## Summary
- expand single-line partial selections to the full enclosing rewritable JIRA reference before toggle classification
- fix template-generated wikilinks so selecting only part of the link still toggles back to the bare issue key
- bump the plugin to `1.2.1` and document the reopened JB-21 fix in the changelog

## Validation
- npm test
- npm run typecheck
- npm run build
