### PR TITLE
JB-20: fix internal issue-link hover preview

### DIFF
--- a/src/hover-preview.test.ts
+++ b/src/hover-preview.test.ts
@@ -146,6 +146,7 @@ describe("hover-preview boundary detection", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     appendChildSpy.mockRestore();
   });
 
@@ -415,6 +416,17 @@ describe("hover-preview boundary detection", () => {
     expect(popover.getAttribute("data-jb-anchor-key")).toBe("ABC-123");
   });
 
+  it("does not resolve non-JIRA anchors from visible text alone", () => {
+    registerHoverPreview(plugin, service, () => BASE_URL);
+
+    const anchor = createAnchor("ABC-123 planning doc", "https://example.com/docs/abc-123");
+    container.appendChild(anchor);
+
+    anchor.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(document.querySelector(".jb-hover-popover")).toBeNull();
+  });
+
   it("resolves rendered internal links through stub frontmatter", () => {
     plugin = createMockPlugin({
       activeFilePath: "Notes/Daily.md",
@@ -446,6 +458,27 @@ describe("hover-preview boundary detection", () => {
     const popover = document.querySelector(".jb-hover-popover") as HTMLElement;
     expect(popover).not.toBeNull();
     expect(popover.getAttribute("data-jb-anchor-key")).toBe("ABC-123");
+  });
+
+  it("does not resolve arbitrary note links from a basename-like key", () => {
+    plugin = createMockPlugin({
+      activeFilePath: "Notes/Daily.md",
+      resolvedLinks: {
+        "Projects/ABC-123 Retrospective": {
+          path: "Projects/ABC-123 Retrospective.md",
+        },
+      },
+    });
+    registerHoverPreview(plugin, service, () => BASE_URL);
+
+    const anchor = createAnchor("Sprint retrospective", "app://obsidian.md/open");
+    anchor.className = "internal-link";
+    anchor.setAttribute("data-href", "Projects/ABC-123 Retrospective");
+    container.appendChild(anchor);
+
+    anchor.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(document.querySelector(".jb-hover-popover")).toBeNull();
   });
 
   it("resolves live preview internal links when alias text hides the key", () => {
@@ -480,5 +513,85 @@ describe("hover-preview boundary detection", () => {
     const popover = document.querySelector(".jb-hover-popover") as HTMLElement;
     expect(popover).not.toBeNull();
     expect(popover.getAttribute("data-jb-anchor-key")).toBe("ABC-123");
+  });
+
+  it("ignores embeds even when they point at an issue stub", () => {
+    plugin = createMockPlugin({
+      activeFilePath: "Notes/Daily.md",
+      resolvedLinks: {
+        "JIRA/ABC-123 Test issue": {
+          path: "JIRA/ABC-123 Test issue.md",
+          jiraKey: "ABC-123",
+        },
+      },
+    });
+    registerHoverPreview(plugin, service, () => BASE_URL);
+
+    const embed = document.createElement("div");
+    embed.className = "internal-embed";
+    embed.setAttribute("data-href", "JIRA/ABC-123 Test issue");
+    const child = document.createElement("div");
+    embed.appendChild(child);
+    container.appendChild(embed);
+
+    child.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(document.querySelector(".jb-hover-popover")).toBeNull();
+  });
+
+  it("cleans up anchor mouseenter handlers across repeated hover cycles", () => {
+    vi.useFakeTimers();
+    registerHoverPreview(plugin, service, () => BASE_URL);
+
+    const anchor = createAnchor("ABC-123", `${BASE_URL}/browse/ABC-123`);
+    container.appendChild(anchor);
+
+    mockElementRect(anchor, {
+      left: 100,
+      top: 100,
+      right: 180,
+      bottom: 120,
+      width: 80,
+      height: 20,
+    });
+
+    let mouseenterAdds = 0;
+    let mouseenterRemoves = 0;
+    const originalAdd = anchor.addEventListener.bind(anchor);
+    const originalRemove = anchor.removeEventListener.bind(anchor);
+
+    vi.spyOn(anchor, "addEventListener").mockImplementation(
+      ((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
+        if (type === "mouseenter") mouseenterAdds++;
+        originalAdd(type, listener, options);
+      }) as typeof anchor.addEventListener,
+    );
+    vi.spyOn(anchor, "removeEventListener").mockImplementation(
+      ((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) => {
+        if (type === "mouseenter") mouseenterRemoves++;
+        originalRemove(type, listener, options);
+      }) as typeof anchor.removeEventListener,
+    );
+
+    for (let i = 0; i < 2; i++) {
+      anchor.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      const popover = document.querySelector(".jb-hover-popover") as HTMLElement;
+      expect(popover).not.toBeNull();
+
+      vi.spyOn(anchor, "matches").mockImplementation((selector: string) =>
+        selector === ":hover" ? false : HTMLElement.prototype.matches.call(anchor, selector),
+      );
+      vi.spyOn(popover, "matches").mockImplementation((selector: string) =>
+        selector === ":hover" ? false : HTMLElement.prototype.matches.call(popover, selector),
+      );
+
+      anchor.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+      vi.advanceTimersByTime(250);
+
+      expect(document.querySelector(".jb-hover-popover")).toBeNull();
+      expect(anchor.getAttribute("data-jb-hover-bound")).toBeNull();
+    }
+
+    expect(mouseenterAdds).toBe(mouseenterRemoves);
   });
 });

--- a/src/hover-preview.test.ts
+++ b/src/hover-preview.test.ts
@@ -6,13 +6,43 @@ import type { IssueService, LookupResult } from "./issue-service";
 
 const BASE_URL = "https://jira.example.com";
 
-function createMockPlugin(): Plugin {
+function createMockPlugin(opts?: {
+  activeFilePath?: string;
+  resolvedLinks?: Record<string, { path: string; basename?: string; jiraKey?: string }>;
+}): Plugin {
   const listeners: Array<{
     el: Document | HTMLElement;
     type: string;
     handler: EventListener;
   }> = [];
+  const resolvedLinks = opts?.resolvedLinks ?? {};
   return {
+    app: {
+      metadataCache: {
+        getFirstLinkpathDest(linkpath: string) {
+          const hit = resolvedLinks[linkpath];
+          if (!hit) return null;
+          const basename =
+            hit.basename ??
+            hit.path
+              .split("/")
+              .pop()
+              ?.replace(/\.md$/, "") ??
+            "";
+          return { path: hit.path, basename } as any;
+        },
+        getFileCache(file: { path: string }) {
+          const hit = Object.values(resolvedLinks).find((entry) => entry.path === file.path);
+          if (!hit?.jiraKey) return null;
+          return { frontmatter: { jira_key: hit.jiraKey } } as any;
+        },
+      },
+      workspace: {
+        getActiveFile() {
+          return opts?.activeFilePath ? ({ path: opts.activeFilePath } as any) : null;
+        },
+      },
+    },
     registerDomEvent(el: Document | HTMLElement, type: string, handler: EventListener) {
       listeners.push({ el, type, handler });
       el.addEventListener(type, handler);
@@ -367,6 +397,73 @@ describe("hover-preview boundary detection", () => {
     const span = document.createElement("span");
     span.className = "cm-link";
     span.textContent = "ABC-123";
+    container.appendChild(span);
+
+    mockElementRect(span, {
+      left: 100,
+      top: 100,
+      right: 180,
+      bottom: 120,
+      width: 80,
+      height: 20,
+    });
+
+    span.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    const popover = document.querySelector(".jb-hover-popover") as HTMLElement;
+    expect(popover).not.toBeNull();
+    expect(popover.getAttribute("data-jb-anchor-key")).toBe("ABC-123");
+  });
+
+  it("resolves rendered internal links through stub frontmatter", () => {
+    plugin = createMockPlugin({
+      activeFilePath: "Notes/Daily.md",
+      resolvedLinks: {
+        "JIRA/ABC-123 Test issue": {
+          path: "JIRA/ABC-123 Test issue.md",
+          jiraKey: "ABC-123",
+        },
+      },
+    });
+    registerHoverPreview(plugin, service, () => BASE_URL);
+
+    const anchor = createAnchor("Test issue", "app://obsidian.md/open");
+    anchor.className = "internal-link";
+    anchor.setAttribute("data-href", "JIRA/ABC-123 Test issue");
+    container.appendChild(anchor);
+
+    mockElementRect(anchor, {
+      left: 100,
+      top: 100,
+      right: 180,
+      bottom: 120,
+      width: 80,
+      height: 20,
+    });
+
+    anchor.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    const popover = document.querySelector(".jb-hover-popover") as HTMLElement;
+    expect(popover).not.toBeNull();
+    expect(popover.getAttribute("data-jb-anchor-key")).toBe("ABC-123");
+  });
+
+  it("resolves live preview internal links when alias text hides the key", () => {
+    plugin = createMockPlugin({
+      activeFilePath: "Notes/Daily.md",
+      resolvedLinks: {
+        "JIRA/ABC-123 Test issue": {
+          path: "JIRA/ABC-123 Test issue.md",
+          jiraKey: "ABC-123",
+        },
+      },
+    });
+    registerHoverPreview(plugin, service, () => BASE_URL);
+
+    const span = document.createElement("span");
+    span.className = "cm-link";
+    span.textContent = "Test issue";
+    span.setAttribute("data-href", "JIRA/ABC-123 Test issue");
     container.appendChild(span);
 
     mockElementRect(span, {

--- a/src/hover-preview.ts
+++ b/src/hover-preview.ts
@@ -1,11 +1,11 @@
 import { Plugin } from "obsidian";
 import type { IssueService } from "./issue-service";
-import { extractKeyFromHref } from "./jira-key";
+import { extractKeyFromHref, findKeyInText } from "./jira-key";
 import { renderIssue } from "./issue-preview-view";
 
 const POPOVER_CLASS = "jb-hover-popover";
 const ATTR_BOUND = "data-jb-hover-bound";
-const KEY_RE = /\b([A-Z][A-Z0-9]+-\d+)\b/;
+const EXACT_KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/;
 
 export function registerHoverPreview(
   plugin: Plugin,
@@ -18,7 +18,7 @@ export function registerHoverPreview(
     const baseUrl = getBaseUrl();
     if (!baseUrl) return;
 
-    const found = findKeyAt(target, baseUrl);
+    const found = findKeyAt(plugin, target, baseUrl);
     if (!found) return;
     if (found.anchorEl.getAttribute(ATTR_BOUND) === "1") return;
 
@@ -31,23 +31,48 @@ export function registerHoverPreview(
 }
 
 function findKeyAt(
+  plugin: Plugin,
   target: HTMLElement,
   baseUrl: string,
 ): { key: string; anchorEl: HTMLElement } | null {
+  const internalLink = target.closest<HTMLElement>("[data-href]");
+  if (internalLink) {
+    const key = extractKeyFromInternalLink(plugin, internalLink);
+    if (key) return { key, anchorEl: internalLink };
+  }
+
   // Reading view: real <a href="…/browse/KEY">
   const a = target.closest<HTMLAnchorElement>("a[href]");
   if (a) {
-    const k = extractKeyFromHref(a.href, baseUrl);
+    const k = extractKeyFromHref(a.href, baseUrl) ?? findKeyInText(a.textContent ?? "");
     if (k) return { key: k, anchorEl: a };
   }
   // Live Preview: hover on a span.cm-link decoration. The URL is hidden;
   // extract a JIRA key from the visible link text.
   const linkSpan = target.closest<HTMLElement>("span.cm-link");
   if (linkSpan) {
-    const m = (linkSpan.textContent ?? "").match(KEY_RE);
-    if (m) return { key: m[1], anchorEl: linkSpan };
+    const key = findKeyInText(linkSpan.textContent ?? "");
+    if (key) return { key, anchorEl: linkSpan };
   }
   return null;
+}
+
+function extractKeyFromInternalLink(plugin: Plugin, linkEl: HTMLElement): string | null {
+  const linkTarget = linkEl.getAttribute("data-href")?.trim();
+  if (!linkTarget) return null;
+
+  const sourcePath = plugin.app.workspace.getActiveFile()?.path ?? "";
+  const file = plugin.app.metadataCache.getFirstLinkpathDest(linkTarget, sourcePath);
+  if (file) {
+    const rawKey = plugin.app.metadataCache.getFileCache(file)?.frontmatter?.jira_key;
+    if (typeof rawKey === "string") {
+      const key = rawKey.trim();
+      if (EXACT_KEY_RE.test(key)) return key;
+    }
+    return findKeyInText(file.basename) ?? findKeyInText(linkTarget);
+  }
+
+  return findKeyInText(linkTarget) ?? findKeyInText(linkEl.textContent ?? "");
 }
 
 function openPopover(

--- a/src/hover-preview.ts
+++ b/src/hover-preview.ts
@@ -6,6 +6,7 @@ import { renderIssue } from "./issue-preview-view";
 const POPOVER_CLASS = "jb-hover-popover";
 const ATTR_BOUND = "data-jb-hover-bound";
 const EXACT_KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/;
+const INTERNAL_LINK_SELECTOR = "a.internal-link[data-href], span.cm-link[data-href]";
 
 export function registerHoverPreview(
   plugin: Plugin,
@@ -23,9 +24,6 @@ export function registerHoverPreview(
     if (found.anchorEl.getAttribute(ATTR_BOUND) === "1") return;
 
     found.anchorEl.setAttribute(ATTR_BOUND, "1");
-    found.anchorEl.addEventListener("mouseenter", () =>
-      openPopover(found.anchorEl, found.key, service, baseUrl),
-    );
     openPopover(found.anchorEl, found.key, service, baseUrl);
   });
 }
@@ -35,7 +33,7 @@ function findKeyAt(
   target: HTMLElement,
   baseUrl: string,
 ): { key: string; anchorEl: HTMLElement } | null {
-  const internalLink = target.closest<HTMLElement>("[data-href]");
+  const internalLink = target.closest<HTMLElement>(INTERNAL_LINK_SELECTOR);
   if (internalLink) {
     const key = extractKeyFromInternalLink(plugin, internalLink);
     if (key) return { key, anchorEl: internalLink };
@@ -44,7 +42,7 @@ function findKeyAt(
   // Reading view: real <a href="…/browse/KEY">
   const a = target.closest<HTMLAnchorElement>("a[href]");
   if (a) {
-    const k = extractKeyFromHref(a.href, baseUrl) ?? findKeyInText(a.textContent ?? "");
+    const k = extractKeyFromHref(a.href, baseUrl);
     if (k) return { key: k, anchorEl: a };
   }
   // Live Preview: hover on a span.cm-link decoration. The URL is hidden;
@@ -63,16 +61,15 @@ function extractKeyFromInternalLink(plugin: Plugin, linkEl: HTMLElement): string
 
   const sourcePath = plugin.app.workspace.getActiveFile()?.path ?? "";
   const file = plugin.app.metadataCache.getFirstLinkpathDest(linkTarget, sourcePath);
-  if (file) {
-    const rawKey = plugin.app.metadataCache.getFileCache(file)?.frontmatter?.jira_key;
-    if (typeof rawKey === "string") {
-      const key = rawKey.trim();
-      if (EXACT_KEY_RE.test(key)) return key;
-    }
-    return findKeyInText(file.basename) ?? findKeyInText(linkTarget);
-  }
+  if (!file) return null;
 
-  return findKeyInText(linkTarget) ?? findKeyInText(linkEl.textContent ?? "");
+  // Only trust explicit stub metadata here; guessing from filenames or alias
+  // text misclassifies arbitrary note links as JIRA issues.
+  const rawKey = plugin.app.metadataCache.getFileCache(file)?.frontmatter?.jira_key;
+  if (typeof rawKey !== "string") return null;
+
+  const key = rawKey.trim();
+  return EXACT_KEY_RE.test(key) ? key : null;
 }
 
 function openPopover(


### PR DESCRIPTION
## Summary
- resolve hover previews for Obsidian internal links that point at synced JIRA stub notes
- read `jira_key` from the target stub frontmatter so aliased links still preview correctly
- add regression coverage for rendered and live-preview internal link cases

## Validation
- npm test
- npm run typecheck
- npm run build

Refs #36